### PR TITLE
Enable FAKETOUCH feature

### DIFF
--- a/common/device.mk
+++ b/common/device.mk
@@ -162,4 +162,9 @@ PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-service.vbt \
     libbt-vendor
 
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.faketouch.multitouch.distinct.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.faketouch.multitouch.distinct.xml \
+    frameworks/native/data/etc/android.hardware.faketouch.multitouch.jazzhand.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.faketouch.multitouch.jazzhand.xml \
+    frameworks/native/data/etc/android.hardware.faketouch.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.faketouch.xml \
+
 PRODUCT_PACKAGE_OVERLAYS += device/intel/cic/common/bluetooth/tablet/overlay


### PR DESCRIPTION
Enable FAKETOUCH feature.
Solve the Input devices cts fake touch issue.
This interface provides a user input system that emulates 
a subset of a touchscreen's capabilities.
eg: on-screen cursor using mouse or remote control.

Tracked-on: OAM-89716
Signed-off-by: rbabub <ramesh.babu.b@intel.com>