### PR TITLE
camera: Remove stream maximum buffer size check

### DIFF
--- a/patches/common/hardware/interfaces/0001-camera-Remove-stream-maximum-buffer-size-check.patch
+++ b/patches/common/hardware/interfaces/0001-camera-Remove-stream-maximum-buffer-size-check.patch
@@ -1,0 +1,38 @@
+From a7a6384558d435b56e34e75490d2c9d5c7a306d5 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Tue, 19 Nov 2019 23:00:12 +0530
+Subject: [PATCH] camera: Remove stream maximum buffer size check
+
+With few cameras, maximum buffer size is returned more than
+the buffer size calculated based on resolution. Due to maximum
+buffer size mismatch between hardware returned buffer size
+and hal calculated buffer size not able to use the camera.
+
+Fix the issue by removing the buffer size check.
+
+Tracked-On: OAM-88579
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ camera/device/3.4/default/ExternalCameraDeviceSession.cpp | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/camera/device/3.4/default/ExternalCameraDeviceSession.cpp b/camera/device/3.4/default/ExternalCameraDeviceSession.cpp
+index 1af3f39ef..eba6b1dc8 100644
+--- a/camera/device/3.4/default/ExternalCameraDeviceSession.cpp
++++ b/camera/device/3.4/default/ExternalCameraDeviceSession.cpp
+@@ -2217,12 +2217,6 @@ int ExternalCameraDeviceSession::configureV4l2StreamLocked(
+     }
+     uint32_t bufferSize = fmt.fmt.pix.sizeimage;
+     ALOGI("%s: V4L2 buffer size is %d", __FUNCTION__, bufferSize);
+-    uint32_t expectedMaxBufferSize = kMaxBytesPerPixel * fmt.fmt.pix.width * fmt.fmt.pix.height;
+-    if ((bufferSize == 0) || (bufferSize > expectedMaxBufferSize)) {
+-        ALOGE("%s: V4L2 buffer size: %u looks invalid. Expected maximum size: %u", __FUNCTION__,
+-                bufferSize, expectedMaxBufferSize);
+-        return -EINVAL;
+-    }
+     mMaxV4L2BufferSize = bufferSize;
+ 
+     const double kDefaultFps = 30.0;
+-- 
+2.17.1
+


### PR DESCRIPTION
With few cameras, maximum buffer size is returned more than
the buffer size calculated based on resolution. Due to maximum
buffer size mismatch between hardware returned buffer size
and hal calculated buffer size not able to use the camera.

Fix the issue by removing the buffer size check.

Tracked-On: OAM-88579
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>