### PR TITLE
device:intel:common: Changes to set role to device by default.

### DIFF
--- a/common/init.base.usb.rc
+++ b/common/init.base.usb.rc
@@ -27,7 +27,8 @@ on boot
     write /config/usb_gadget/g1/configs/b.1/MaxPower 500
     symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
     setprop sys.usb.configfs 1
-    setprop sys.usb.controller "700d0000.usb-device"
+    setprop sys.usb.controller "dwc3.0.auto"
+    write /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role device
 
 on property:sys.usb.config=none && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/os_desc/use 0


### PR DESCRIPTION
This patch will set the default role to device. So that cic can
detect on Host PC via USB cable.

Tracked-On: OAM-88660
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>