### PR TITLE
kernel Patches to be applied to host CIC kernel to enable ADB over USB

### DIFF
--- a/common/host/0001-driver-usb-role-roles-Fix-USB-3.0-OTG-issue-on-Intel.patch
+++ b/common/host/0001-driver-usb-role-roles-Fix-USB-3.0-OTG-issue-on-Intel.patch
@@ -1,0 +1,54 @@
+From c707b5f3c8e3c7b98b772d3b75c106850bcc651e Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Tue, 26 Nov 2019 14:30:27 +0530
+Subject: [PATCH] driver:usb:role: roles: Fix USB 3.0 OTG issue on Intel
+ platform
+
+This patch adds static DRD mode for host/device mode switch. This fixes the issue where device mode was not working after DUT switches to host mode with 3.0 OTG connector.
+
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ drivers/usb/roles/intel-xhci-usb-role-switch.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/usb/roles/intel-xhci-usb-role-switch.c b/drivers/usb/roles/intel-xhci-usb-role-switch.c
+index 277de96181f9..b90053be745e 100644
+--- a/drivers/usb/roles/intel-xhci-usb-role-switch.c
++++ b/drivers/usb/roles/intel-xhci-usb-role-switch.c
+@@ -26,6 +26,9 @@
+ #define SW_VBUS_VALID			BIT(24)
+ #define SW_IDPIN_EN			BIT(21)
+ #define SW_IDPIN			BIT(20)
++#define SW_SWITCH_EN_CFG0		BIT(16)
++#define SW_DRD_STATIC_HOST_CFG0		1
++#define SW_DRD_STATIC_DEV_CFG0		2
+ 
+ #define DUAL_ROLE_CFG1			0x6c
+ #define HOST_MODE			BIT(29)
+@@ -65,17 +68,22 @@ static int intel_xhci_usb_set_role(struct device *dev, enum usb_role role)
+ 	case USB_ROLE_NONE:
+ 		val |= SW_IDPIN;
+ 		val &= ~SW_VBUS_VALID;
++		val &= ~(SW_DRD_STATIC_DEV_CFG0 | SW_DRD_STATIC_HOST_CFG0);
+ 		break;
+ 	case USB_ROLE_HOST:
+ 		val &= ~SW_IDPIN;
+ 		val &= ~SW_VBUS_VALID;
++		val &= ~SW_DRD_STATIC_DEV_CFG0;
++		val |= SW_DRD_STATIC_HOST_CFG0;
+ 		break;
+ 	case USB_ROLE_DEVICE:
+ 		val |= SW_IDPIN;
+ 		val |= SW_VBUS_VALID;
++		val &= ~SW_DRD_STATIC_HOST_CFG0;
++		val |= SW_DRD_STATIC_DEV_CFG0;
+ 		break;
+ 	}
+-	val |= SW_IDPIN_EN;
++	val |= SW_IDPIN_EN | SW_SWITCH_EN_CFG0;
+ 
+ 	writel(val, data->base + DUAL_ROLE_CFG0);
+ 
+-- 
+2.17.1
+

--- a/common/host/0002-kernel-drivers-usb-dwc3-Patch-to-force-USB-speed-to-.patch
+++ b/common/host/0002-kernel-drivers-usb-dwc3-Patch-to-force-USB-speed-to-.patch
@@ -1,0 +1,65 @@
+From ea13436e247500ae5cee41eb7d4ca85b44d47a9d Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Wed, 27 Nov 2019 14:56:29 +0530
+Subject: [PATCH] kernel:drivers:usb:dwc3: Patch to force USB speed to usb2.0
+
+This patch will force the device speed to usb 2.0 even if
+we connect usb3.0 or usb3.1 cable. As only usb2.0 is working on
+KBL platform due to h/w limitation.
+
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ drivers/usb/dwc3/gadget.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/dwc3/gadget.c b/drivers/usb/dwc3/gadget.c
+index b0884ffd3f7d..e4ffbbfe68d9 100644
+--- a/drivers/usb/dwc3/gadget.c
++++ b/drivers/usb/dwc3/gadget.c
+@@ -1922,6 +1922,17 @@ static void dwc3_gadget_setup_nump(struct dwc3 *dwc)
+ 	dwc3_writel(dwc->regs, DWC3_DCFG, reg);
+ }
+ 
++static inline bool platform_is_bxtp(void)
++{
++#ifdef CONFIG_X86_64
++	if ((boot_cpu_data.x86_model == 0x5c || boot_cpu_data.x86_model == 0x8e)
++		&& (boot_cpu_data.x86_stepping >= 0x8)
++		&& (boot_cpu_data.x86_stepping <= 0xf))
++		return true;
++#endif
++	return false;
++}
++
+ static int __dwc3_gadget_start(struct dwc3 *dwc)
+ {
+ 	struct dwc3_ep		*dep;
+@@ -2099,10 +2110,23 @@ static void dwc3_gadget_set_speed(struct usb_gadget *g,
+ 			reg |= DWC3_DCFG_HIGHSPEED;
+ 			break;
+ 		case USB_SPEED_SUPER:
+-			reg |= DWC3_DCFG_SUPERSPEED;
++			/*
++			 * WORKAROUND: BXTP platform USB3.0 port SS fail,
++			 * We switch SS to HS to enable USB3.0.
++			 */
++			if (platform_is_bxtp())
++				reg |= DWC3_DCFG_HIGHSPEED;
++			else
++				reg |= DWC3_DCFG_SUPERSPEED;
+ 			break;
+ 		case USB_SPEED_SUPER_PLUS:
+-			if (dwc3_is_usb31(dwc))
++			/*
++			 * WORKAROUND: BXTP platform USB3.0 port SS fail,
++			 * We switch SS to HS to enable USB3.0.
++			 */
++			if (platform_is_bxtp())
++				reg |= DWC3_DCFG_HIGHSPEED;
++			else if (dwc3_is_usb31(dwc))
+ 				reg |= DWC3_DCFG_SUPERSPEED_PLUS;
+ 			else
+ 				reg |= DWC3_DCFG_SUPERSPEED;
+-- 
+2.17.1
+


### PR DESCRIPTION
These patches will enable ADB Over USB in CIC.

Tracked-On: OAM-88679
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>