### PR TITLE
Add "persist.sys.statusbar.hidden" to control the statusbar

### DIFF
--- a/patches/cic_dev/frameworks/base/0001-Add-persist.intel.statusbar.hidden-to-control-the-st.patch
+++ b/patches/cic_dev/frameworks/base/0001-Add-persist.intel.statusbar.hidden-to-control-the-st.patch
@@ -1,0 +1,45 @@
+From 60f8ecf1c3bd8167abc4242eff525bbcf9bc4e25 Mon Sep 17 00:00:00 2001
+From: shellyxx <shellyx.xie@intel.com>
+Date: Thu, 5 Dec 2019 17:02:12 +0800
+Subject: [PATCH] Add "persist.sys.statusbar.hidden" to control the statusbar
+
+TvStatusBar is a null statusbar, set persist.sys.statusbar.hidden to true,
+when need hidden the statusbar.
+
+Tracked-On: OAM-88704
+Signed-off-by: Xie, ShellyX <shellyx.xie@intel.com>
+---
+ .../SystemUI/src/com/android/systemui/SystemBars.java  | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/SystemBars.java b/packages/SystemUI/src/com/android/systemui/SystemBars.java
+index b5093b3ce52..0c8cea86696 100644
+--- a/packages/SystemUI/src/com/android/systemui/SystemBars.java
++++ b/packages/SystemUI/src/com/android/systemui/SystemBars.java
+@@ -15,6 +15,7 @@
+ package com.android.systemui;
+ 
+ import android.content.res.Configuration;
++import android.os.SystemProperties;
+ import android.provider.Settings;
+ import android.util.Log;
+ 
+@@ -51,7 +52,14 @@ public class SystemBars extends SystemUI {
+ 
+     private void createStatusBarFromConfig() {
+         if (DEBUG) Log.d(TAG, "createStatusBarFromConfig");
+-        final String clsName = mContext.getString(R.string.config_statusBarComponent);
++        String clsName = mContext.getString(R.string.config_statusBarComponent);
++
++        // TvStatusBar is a null statusbar, set persist.sys.statusbar.hidden to true,
++        // when need to hidden the statusbar.
++        if ("true".equals(SystemProperties.get("persist.sys.statusbar.hidden"))) {
++            clsName = "com.android.systemui.statusbar.tv.TvStatusBar";
++        }
++
+         if (clsName == null || clsName.length() == 0) {
+             throw andLog("No status bar component configured", null);
+         }
+-- 
+2.17.1
+


### PR DESCRIPTION
TvStatusBar is a null statusbar, set persist.sys.statusbar.hidden to true,
when need hidden the statusbar.

Tracked-On: OAM-88704
Signed-off-by: Xie, ShellyX <shellyx.xie@intel.com>