### PR TITLE
[do not merge] set path for build scripts

### DIFF
--- a/common/BoardConfig.mk
+++ b/common/BoardConfig.mk
@@ -2,6 +2,9 @@
 #
 # Product-specific compile-time definitions.
 #
+INTEL_PATH_COMMON := device/intel/common
+INTEL_PATH_BUILD := device/intel/build
+INTEL_PATH_VENDOR := vendor/intel
 
 # The generic product target doesn't have any hardware-specific pieces.
 TARGET_NO_BOOTLOADER := true


### PR DESCRIPTION
path for build scripts should be set by mixins.
this is hot fix for build failure

Tracked-On: OAM-88857
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>