### PR TITLE
Don't initialize healthd wakealarm in CIC

### DIFF
--- a/patches/common/hardware/interfaces/0002-Don-t-initialize-healthd-wakealarm-in-CIC.patch
+++ b/patches/common/hardware/interfaces/0002-Don-t-initialize-healthd-wakealarm-in-CIC.patch
@@ -1,0 +1,47 @@
+From c197ede12b98437aae3aa23c33a8d3911dd3d03d Mon Sep 17 00:00:00 2001
+From: Hongcheng Xie <hongcheng.xie@intel.com>
+Date: Fri, 3 Jan 2020 21:03:35 +0800
+Subject: [PATCH] Don't initialize healthd wakealarm in CIC
+
+The healthd wakealarm will wakeup system by periodic interval,
+that lead to the device will be wakeup in a short time after
+sleep,especially when AC charger plug in for laptop device.
+
+We don't need to initialize wakealarm to monitor health status
+in container, Host will do that.
+
+Change-Id: Ibb94091490490154dffc6c3fb93405a5a607c089
+Tracked-On: OAM-88913
+Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>
+---
+ health/2.0/default/healthd_common.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/health/2.0/default/healthd_common.cpp b/health/2.0/default/healthd_common.cpp
+index 8ff409dd5..d8204e8b9 100644
+--- a/health/2.0/default/healthd_common.cpp
++++ b/health/2.0/default/healthd_common.cpp
+@@ -77,6 +77,8 @@ static int awake_poll_interval = -1;
+ 
+ static int wakealarm_wake_interval = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST;
+ 
++static int no_need_wakealarm_interval = 1;
++
+ using ::android::hardware::health::V2_0::implementation::Health;
+ 
+ struct healthd_mode_ops* healthd_mode_ops = nullptr;
+@@ -198,6 +200,11 @@ static void wakealarm_event(uint32_t /*epevents*/) {
+ }
+ 
+ static void wakealarm_init(void) {
++    if (no_need_wakealarm_interval == 1) {
++        KLOG_WARNING(LOG_TAG, "wakealarm_init: we don't need to initialize wakealarm\n");
++        return;
++    }
++
+     wakealarm_fd = timerfd_create(CLOCK_BOOTTIME_ALARM, TFD_NONBLOCK);
+     if (wakealarm_fd == -1) {
+         KLOG_ERROR(LOG_TAG, "wakealarm_init: timerfd_create failed\n");
+-- 
+2.17.1
+


### PR DESCRIPTION
The healthd wakealarm will wakeup system by periodic interval,
that lead to the device will be wakeup in a short time after
sleep,especially when AC charger plug in for laptop device.

We don't need to initialize wakealarm to monitor health status
in container, Host will do that.

Tracked-On: OAM-88913
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>