### PR TITLE
Workaround the audio and video flickering issue during seeking

### DIFF
--- a/patches/common/packages/apps/Gallery2/0001-Workaround-the-audio-and-video-flickering-issue-duri.patch
+++ b/patches/common/packages/apps/Gallery2/0001-Workaround-the-audio-and-video-flickering-issue-duri.patch
@@ -1,0 +1,61 @@
+From 6e2aed12b7c264e96556d8beb098e5bef2367a6a Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Tue, 7 Jan 2020 12:07:27 +0800
+Subject: [PATCH] Workaround the audio and video flickering issue during
+ seeking
+
+Pause the video playback during seeking.
+
+Change-Id: I3c6e7e75eba3d16ad15d114b4ffeb641c494f356
+Tracked-On: OAM-88796
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+---
+ src/com/android/gallery3d/app/CommonControllerOverlay.java | 7 +++++++
+ src/com/android/gallery3d/app/MoviePlayer.java             | 6 ++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/src/com/android/gallery3d/app/CommonControllerOverlay.java b/src/com/android/gallery3d/app/CommonControllerOverlay.java
+index 9adb4e7..97085b9 100644
+--- a/src/com/android/gallery3d/app/CommonControllerOverlay.java
++++ b/src/com/android/gallery3d/app/CommonControllerOverlay.java
+@@ -132,6 +132,13 @@ public abstract class CommonControllerOverlay extends FrameLayout implements
+         return view;
+     }
+ 
++    public boolean getPlayingState() {
++        if(mState == State.PLAYING){
++            return true;
++        }
++        return false;
++    }
++
+     @Override
+     public void setListener(Listener listener) {
+         this.mListener = listener;
+diff --git a/src/com/android/gallery3d/app/MoviePlayer.java b/src/com/android/gallery3d/app/MoviePlayer.java
+index f6bd367..a3c478d 100644
+--- a/src/com/android/gallery3d/app/MoviePlayer.java
++++ b/src/com/android/gallery3d/app/MoviePlayer.java
+@@ -378,6 +378,9 @@ public class MoviePlayer implements
+     @Override
+     public void onSeekStart() {
+         mDragging = true;
++        if(mController.getPlayingState()){
++            mVideoView.pause();
++        }
+     }
+ 
+     @Override
+@@ -388,6 +391,9 @@ public class MoviePlayer implements
+     @Override
+     public void onSeekEnd(int time, int start, int end) {
+         mDragging = false;
++        if(mController.getPlayingState()){
++            mVideoView.start();
++        }
+         mVideoView.seekTo(time);
+         setProgress();
+     }
+-- 
+2.7.4
+


### PR DESCRIPTION
Pause the video playback during seeking.

Change-Id: I9be10ba26da150f1295512580e9ccf8daf8d29b0
Tracked-On: OAM-88796
Signed-off-by: yingzhex <yingzhenx.li@intel.com>