### PR TITLE
Remove console service on CIC

### DIFF
--- a/patches/common/system/core/0004-Remove-console-service-on-CIC.patch
+++ b/patches/common/system/core/0004-Remove-console-service-on-CIC.patch
@@ -1,0 +1,46 @@
+From 35ef7ef34db5e1f5b8dd47bcc2e047a3831c3cba Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Tue, 14 Jan 2020 21:27:06 +0800
+Subject: [PATCH] Remove console service on CIC
+
+On CIC, we may enter android console during host user logout
+and shutdown host. Here, let's remove console on Android
+
+Tracked-On: OAM-88915
+Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>
+Change-Id: Ia58d33b917395960b8c807ed9bf901b69edd560f
+---
+ rootdir/init.rc | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/rootdir/init.rc b/rootdir/init.rc
+index b9464e7fd8e5..a3e03fae8f18 100644
+--- a/rootdir/init.rc
++++ b/rootdir/init.rc
+@@ -747,14 +747,15 @@ service ueventd /sbin/ueventd
+     seclabel u:r:ueventd:s0
+     shutdown critical
+ 
+-service console /system/bin/sh
+-    class core
+-    console
+-    disabled
+-    user shell
+-    group shell log readproc
+-    seclabel u:r:shell:s0
+-    setenv HOSTNAME console
++# Remove console on CIC
++#service console /system/bin/sh
++#    class core
++#    console
++#    disabled
++#    user shell
++#    group shell log readproc
++#    seclabel u:r:shell:s0
++#    setenv HOSTNAME console
+ 
+ on property:ro.debuggable=1
+     # Give writes to anyone for the trace folder on debug builds.
+-- 
+2.22.0
+


### PR DESCRIPTION
On CIC, we may enter android console during host user logout
and shutdown host. Here, let's remove console on Android

Tracked-On: OAM-88915
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>