### PR TITLE
Fixed the OOM issue when running gfxbench in CIC.

### DIFF
--- a/common/host/README
+++ b/common/host/README
@@ -74,6 +74,10 @@ make ARCH=x86_64 menuconfig
 # "Device Drivers->Network device support -> Wireless LAN->Intel Wireless WiFi 7000 series driver (new version)"
 # Save the config file to same .config file
 
+# Disable Maximum number of SMP Processors and NUMA Nodes for client usage. Not suit for cloud usage!
+# "Processor type and features -> Maximum number of SMP Processors and NUMA Nodes"
+# Set Maximum number of CPUs (NEW) to 32 for client usage. Not suit for cloud usage!
+# "Processor type and features -> Maximum number of CPUs (NEW)"
 
 
 ### SOF kernel compilation instructions


### PR DESCRIPTION
Maximum number of CPUs (NEW) set to 8192 by default results in gfxbench
app generates an oversized binder content and caused gfxbench process
crashed. Let the Ubuntu kernel configurations same with Android kernel
fixed crash issue.

Change-Id: Ibedb5deaebaba84be436f1e41ad9bef86ffae1c3
Tracked-On: OAM-88820
Signed-off-by: Wan Shuang <shuang.wan@intel.com>