### PR TITLE
nvme: pci: suspend resume stability issue fix with QUIRKs

### DIFF
--- a/common/host/storage/0001-nvme-pci-suspend-resume-stability-issue-fix-with-QUI.patch
+++ b/common/host/storage/0001-nvme-pci-suspend-resume-stability-issue-fix-with-QUI.patch
@@ -1,0 +1,43 @@
+From ff1dcf9c267cd29fe872001cbf86d5a145614b49 Mon Sep 17 00:00:00 2001
+From: shyjumon <shyjumon.n@intel.com>
+Date: Sun, 19 Jan 2020 20:46:11 +0530
+Subject: [PATCH] nvme: pci: suspend resume stability issue fix with QUIRKs
+
+When device kept on sleep/suspend mode for long time, runtime resume
+is not happening and system went to hang/unresponsive state with APST enabled.
+Tested on: Samsung SSD SM981/PM981 SSDs and Toshiba SSD KBG40ZNT256G.
+So applying fall back to SIMPLE SUSPEND to improve resume latency.
+Issue is not observed in more than 1 day test.
+
+Tracked-On: OAM-88935
+Signed-off-by: N, shyjumon <shyjumon.n@intel.com>
+Signed-off-by: Jon Derrick <jonathan.derrick@intel.com>
+---
+ drivers/nvme/host/pci.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/nvme/host/pci.c b/drivers/nvme/host/pci.c
+index 0ac8054..bd9c495 100644
+--- a/drivers/nvme/host/pci.c
++++ b/drivers/nvme/host/pci.c
+@@ -2463,6 +2463,17 @@ static unsigned long check_vendor_combination_bug(struct pci_dev *pdev)
+ 		    (dmi_match(DMI_BOARD_NAME, "PRIME B350M-A") ||
+ 		     dmi_match(DMI_BOARD_NAME, "PRIME Z370-A")))
+ 			return NVME_QUIRK_NO_APST;
++	} else if ((pdev->vendor == 0x144d && (pdev->device == 0xa801 ||
++                    pdev->device == 0xa808 || pdev->device == 0xa809)) ||
++                   (pdev->vendor == 0x1e0f && pdev->device == 0x0001)) {
++                /*
++                 * Forcing to use host managed nvme power settings for lowest
++                 * idle power with quicker resume latency on Samsung and Toshiba SSDs
++                 * based on suspend behavior on Coffee Lake board for LENOVO C640
++                 */
++                if ((dmi_match(DMI_BOARD_VENDOR, "LENOVO")) &&
++                     dmi_match(DMI_BOARD_NAME, "LNVNB161216"))
++                        return NVME_QUIRK_SIMPLE_SUSPEND;
+ 	}
+ 
+ 	return 0;
+-- 
+2.7.4
+


### PR DESCRIPTION
When device kept on sleep/suspend mode for long time, runtime resume
is not happening and system went to hang/unresponsive state with APST enabled.
Tested on: Samsung SSD SM981/PM981 SSDs and Toshiba SSD KBG40ZNT256G.
So applying fall back to SIMPLE SUSPEND to improve resume latency.
Issue is not observed in more than 1 day test.

Tracked-On: OAM-88935
Signed-off-by: N, shyjumon <shyjumon.n@intel.com>
Signed-off-by: Jon Derrick <jonathan.derrick@intel.com>