### PR TITLE
device:intel:cic:commmon: Add changes to enable ncm and acm in CIC.

### DIFF
--- a/common/init.base.usb.rc
+++ b/common/init.base.usb.rc
@@ -20,6 +20,8 @@ on boot
     mkdir /config/usb_gadget/g1/functions/rndis.gs4
     write /config/usb_gadget/g1/functions/rndis.gs4/wceis 1
     mkdir /config/usb_gadget/g1/functions/midi.gs5
+    mkdir /config/usb_gadget/g1/functions/ncm.gs6
+    mkdir /config/usb_gadget/g1/functions/acm.gs7
     mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
     mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
     write /config/usb_gadget/g1/os_desc/b_vendor_code 0x1
@@ -95,3 +97,22 @@ on property:sys.usb.config=accessory,audio_source && property:sys.usb.configfs=1
 
 on property:sys.usb.config=accessory,audio_source,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/idProduct 0x2d05
+
+on property:sys.usb.config=ncm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm"
+    symlink /config/usb_gadget/g1/functions/ncm.gs6 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.config=acm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "acm"
+    symlink /config/usb_gadget/g1/functions/acm.gs7 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.config=ncm,acm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm_acm"
+    symlink /config/usb_gadget/g1/functions/ncm.gs6 /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/acm.gs7 /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}


### PR DESCRIPTION
New configs have been added in init.base.usb.rc file to enable
and test ncm and acm gadget in case of CIC.
Steps to Test:
	1. setprop sys.usb.config none
	2. setprop sys.usb.config ncm  (To test ncm)
	3. setprop sys.usb.config none
	4. setprop sys.usb.config acm  (To test acm)
	5. setprop sys.usb.config none
	6. setprop sys.usb.config ncm,acm  (To test ncm,acm)

Tracked-On: OAM-89298
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>