### PR TITLE
Enable the LSM stacking feature

### DIFF
--- a/common/host/security/0001-LSM-Module-stacking-for-AppArmor.patch
+++ b/common/host/security/0001-LSM-Module-stacking-for-AppArmor.patch
@@ -1,0 +1,12595 @@
+From 517ff96e6e43d0e5da5cfb0ab088a2713e65a35a Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Wed, 25 Dec 2019 13:34:42 +0800
+Subject: [PATCH] LSM: Module stacking for AppArmor
+
+This patchset provides the changes required for
+the AppArmor security module to stack safely with any other.
+
+A new process attribute identifies which security module
+information should be reported by SO_PEERSEC and the
+/proc/.../attr/current interface. This is provided by
+/proc/.../attr/display. Writing the name of the security
+module desired to this interface will set which LSM hooks
+will be called for this information. The first security
+module providing the hooks will be used by default.
+
+The use of integer based security tokens (secids) is
+generally (but not completely) replaced by a structure
+lsm_export. The lsm_export structure can contain information
+for each of the security modules that export information
+outside the LSM layer.
+
+The LSM interfaces that provide "secctx" text strings
+have been changed to use a structure "lsm_context"
+instead of a pointer/length pair. In some cases the
+interfaces used a "char *" pointer and in others a
+"void *". This was necessary to ensure that the correct
+release mechanism for the text is used. It also makes
+many of the interfaces cleaner.
+
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ fs/btrfs/super.c                        |    2 +-
+ fs/ecryptfs/kthread.c                   |   60 +-
+ fs/kernfs/dir.c                         |   11 +-
+ fs/kernfs/inode.c                       |   31 +-
+ fs/kernfs/kernfs-internal.h             |    4 +-
+ fs/nfs/inode.c                          |   13 +-
+ fs/nfs/internal.h                       |    8 +-
+ fs/nfs/nfs4proc.c                       |   22 +-
+ fs/nfs/nfs4xdr.c                        |   16 +-
+ fs/nfsd/nfs4proc.c                      |    7 +-
+ fs/nfsd/nfs4xdr.c                       |   14 +-
+ fs/nfsd/vfs.c                           |    7 +-
+ fs/proc/base.c                          |   65 +-
+ fs/proc/internal.h                      |    1 +
+ include/asm-generic/vmlinux.lds.h       |   25 +-
+ include/linux/cred.h                    |    3 +-
+ include/linux/lsm_hooks.h               |  166 +--
+ include/linux/nfs4.h                    |    8 +-
+ include/linux/security.h                |  242 +++--
+ include/net/netlabel.h                  |   10 +-
+ include/net/scm.h                       |   14 +-
+ kernel/audit.c                          |   60 +-
+ kernel/audit.h                          |    8 +-
+ kernel/auditfilter.c                    |    6 +-
+ kernel/auditsc.c                        |   61 +-
+ kernel/capability.c                     |   46 +-
+ kernel/cred.c                           |   26 +-
+ kernel/exit.c                           |    2 -
+ kernel/ptrace.c                         |    4 +-
+ kernel/seccomp.c                        |    4 +-
+ net/ipv4/cipso_ipv4.c                   |    6 +-
+ net/ipv4/ip_sockglue.c                  |   12 +-
+ net/netfilter/nf_conntrack_netlink.c    |   27 +-
+ net/netfilter/nf_conntrack_standalone.c |   22 +-
+ net/netfilter/nfnetlink_queue.c         |   42 +-
+ net/netfilter/xt_SECMARK.c              |   60 +-
+ net/netlabel/netlabel_kapi.c            |    5 +-
+ net/netlabel/netlabel_unlabeled.c       |  102 +-
+ net/netlabel/netlabel_unlabeled.h       |    2 +-
+ net/netlabel/netlabel_user.c            |   45 +-
+ net/netlabel/netlabel_user.h            |    2 +-
+ net/unix/af_unix.c                      |   10 +-
+ security/Kconfig                        |   60 +-
+ security/Makefile                       |    8 +-
+ security/apparmor/Kconfig               |   16 -
+ security/apparmor/apparmorfs.c          |   15 +-
+ security/apparmor/audit.c               |    4 +-
+ security/apparmor/capability.c          |   14 +-
+ security/apparmor/domain.c              |    7 +-
+ security/apparmor/file.c                |    2 +-
+ security/apparmor/include/audit.h       |    2 +-
+ security/apparmor/include/capability.h  |    2 +-
+ security/apparmor/include/cred.h        |   16 +-
+ security/apparmor/include/file.h        |    5 +-
+ security/apparmor/include/lib.h         |    4 +
+ security/apparmor/include/net.h         |   16 +-
+ security/apparmor/include/policy.h      |   14 +-
+ security/apparmor/include/secid.h       |   12 +-
+ security/apparmor/include/task.h        |   18 +-
+ security/apparmor/ipc.c                 |    3 +-
+ security/apparmor/lsm.c                 |  256 +++--
+ security/apparmor/net.c                 |   68 ++
+ security/apparmor/policy.c              |    3 +
+ security/apparmor/policy_unpack.c       |  103 +-
+ security/apparmor/resource.c            |    2 +-
+ security/apparmor/secid.c               |   45 +-
+ security/apparmor/task.c                |    6 +-
+ security/commoncap.c                    |   29 +-
+ security/device_cgroup.c                |    2 +-
+ security/inode.c                        |   15 +-
+ security/integrity/digsig.c             |   10 +-
+ security/integrity/evm/evm_crypto.c     |    7 +-
+ security/integrity/iint.c               |    6 +-
+ security/integrity/ima/ima.h            |   16 +-
+ security/integrity/ima/ima_api.c        |   12 +-
+ security/integrity/ima/ima_appraise.c   |    6 +-
+ security/integrity/ima/ima_crypto.c     |   10 +-
+ security/integrity/ima/ima_fs.c         |    3 +-
+ security/integrity/ima/ima_init.c       |    2 +-
+ security/integrity/ima/ima_main.c       |   36 +-
+ security/integrity/ima/ima_policy.c     |   40 +-
+ security/integrity/ima/ima_template.c   |   11 +-
+ security/loadpin/Kconfig                |    4 +-
+ security/loadpin/loadpin.c              |   82 +-
+ security/lsm_audit.c                    |   10 +-
+ security/security.c                     | 1269 ++++++++++++++++++++---
+ security/selinux/Kconfig                |   25 -
+ security/selinux/Makefile               |    2 +-
+ security/selinux/avc.c                  |   32 +-
+ security/selinux/exports.c              |   23 -
+ security/selinux/hooks.c                |  748 +++++--------
+ security/selinux/include/audit.h        |    9 +-
+ security/selinux/include/avc.h          |    1 -
+ security/selinux/include/classmap.h     |    1 -
+ security/selinux/include/objsec.h       |   78 +-
+ security/selinux/netlabel.c             |   39 +-
+ security/selinux/nlmsgtab.c             |   13 +-
+ security/selinux/selinuxfs.c            |    4 +-
+ security/selinux/ss/mls.c               |  178 ++--
+ security/selinux/ss/mls.h               |    2 +-
+ security/selinux/ss/policydb.c          |   60 +-
+ security/selinux/ss/services.c          |   32 +-
+ security/selinux/xfrm.c                 |    4 +-
+ security/smack/smack.h                  |   77 +-
+ security/smack/smack_access.c           |   12 +-
+ security/smack/smack_lsm.c              |  649 +++++-------
+ security/smack/smack_netfilter.c        |   28 +-
+ security/smack/smackfs.c                |   33 +-
+ security/tomoyo/common.c                |    3 +-
+ security/tomoyo/common.h                |   22 +-
+ security/tomoyo/domain.c                |    4 +-
+ security/tomoyo/securityfs_if.c         |   15 +-
+ security/tomoyo/tomoyo.c                |   54 +-
+ security/tomoyo/util.c                  |    2 +-
+ security/yama/yama_lsm.c                |   12 +-
+ 115 files changed, 3369 insertions(+), 2345 deletions(-)
+ delete mode 100644 security/selinux/exports.c
+
+diff --git a/fs/btrfs/super.c b/fs/btrfs/super.c
+index db4002ecbaca..e9f7603aebf0 100644
+--- a/fs/btrfs/super.c
++++ b/fs/btrfs/super.c
+@@ -1492,7 +1492,7 @@ static int setup_security_options(struct btrfs_fs_info *fs_info,
+ 		return ret;
+ 
+ #ifdef CONFIG_SECURITY
+-	if (!fs_info->security_opts.num_mnt_opts) {
++	if (security_num_mnt_opts(sec_opts) > 0) {
+ 		/* first time security setup, copy sec_opts to fs_info */
+ 		memcpy(&fs_info->security_opts, sec_opts, sizeof(*sec_opts));
+ 	} else {
+diff --git a/fs/ecryptfs/kthread.c b/fs/ecryptfs/kthread.c
+index f488bec0f371..a302b1ccc396 100644
+--- a/fs/ecryptfs/kthread.c
++++ b/fs/ecryptfs/kthread.c
+@@ -142,43 +142,31 @@ int ecryptfs_privileged_open(struct file **lower_file,
+ 	req.path.dentry = lower_dentry;
+ 	req.path.mnt = lower_mnt;
+ 
+-	/*
+-	 * When SELinux is enabled, force the lower file to be opened by the
+-	 * kernel thread.  Otherwise, the lower file will be associated with the
+-	 * SELinux context of the first process that opens it, which may prevent
+-	 * a different process from using it, unless that process has permission
+-	 * to use fds from the first process.
+-	 *
+-	 * If SELinux is enabled, then any process that needs read access to an
+-	 * ecryptfs filesytem must allow fd:use on the kernel context.
+-	 */
+-	if (!selinux_is_enabled()) {
+-		/* Corresponding dput() and mntput() are done when the lower
+-		 * file is fput() when all eCryptfs files for the inode are
+-		 * released. */
+-		flags |= IS_RDONLY(d_inode(lower_dentry)) ? O_RDONLY : O_RDWR;
+-		(*lower_file) = dentry_open(&req.path, flags, cred);
+-		if (!IS_ERR(*lower_file))
+-			goto out;
+-		if ((flags & O_ACCMODE) == O_RDONLY) {
+-			rc = PTR_ERR((*lower_file));
+-			goto out;
+-		}
+-	}
++    /* Corresponding dput() and mntput() are done when the lower
++     * file is fput() when all eCryptfs files for the inode are
++     * released. */
++    flags |= IS_RDONLY(d_inode(lower_dentry)) ? O_RDONLY : O_RDWR;
++    (*lower_file) = dentry_open(&req.path, flags, cred);
++    if (!IS_ERR(*lower_file))
++        goto out;
++    if ((flags & O_ACCMODE) == O_RDONLY) {
++        rc = PTR_ERR((*lower_file));
++        goto out;
++    }
+ 
+-	mutex_lock(&ecryptfs_kthread_ctl.mux);
+-	if (ecryptfs_kthread_ctl.flags & ECRYPTFS_KTHREAD_ZOMBIE) {
+-		rc = -EIO;
+-		mutex_unlock(&ecryptfs_kthread_ctl.mux);
+-		printk(KERN_ERR "%s: We are in the middle of shutting down; "
+-		       "aborting privileged request to open lower file\n",
+-			__func__);
+-		goto out;
+-	}
+-	list_add_tail(&req.kthread_ctl_list, &ecryptfs_kthread_ctl.req_list);
+-	mutex_unlock(&ecryptfs_kthread_ctl.mux);
+-	wake_up(&ecryptfs_kthread_ctl.wait);
+-	wait_for_completion(&req.done);
++    mutex_lock(&ecryptfs_kthread_ctl.mux);
++    if (ecryptfs_kthread_ctl.flags & ECRYPTFS_KTHREAD_ZOMBIE) {
++        rc = -EIO;
++        mutex_unlock(&ecryptfs_kthread_ctl.mux);
++        printk(KERN_ERR "%s: We are in the middle of shutting down; "
++          "aborting privileged request to open lower file\n",
++          __func__);
++        goto out;
++    }
++    list_add_tail(&req.kthread_ctl_list, &ecryptfs_kthread_ctl.req_list);
++    mutex_unlock(&ecryptfs_kthread_ctl.mux);
++    wake_up(&ecryptfs_kthread_ctl.wait);
++    wait_for_completion(&req.done);
+ 	if (IS_ERR(*lower_file))
+ 		rc = PTR_ERR(*lower_file);
+ out:
+diff --git a/fs/kernfs/dir.c b/fs/kernfs/dir.c
+index a4a538abcaf9..9e25a37b12fd 100644
+--- a/fs/kernfs/dir.c
++++ b/fs/kernfs/dir.c
+@@ -532,9 +532,9 @@ void kernfs_put(struct kernfs_node *kn)
+ 	kfree_const(kn->name);
+ 
+ 	if (kn->iattr) {
+-		if (kn->iattr->ia_secdata)
+-			security_release_secctx(kn->iattr->ia_secdata,
+-						kn->iattr->ia_secdata_len);
++		if (kn->iattr->ia_context.context)
++			security_release_secctx(
++					&kn->iattr->ia_context);
+ 		simple_xattrs_free(&kn->iattr->xattrs);
+ 	}
+ 	kfree(kn->iattr);
+@@ -649,10 +649,11 @@ static struct kernfs_node *__kernfs_new_node(struct kernfs_root *root,
+ 	kn->id.generation = gen;
+ 
+ 	/*
+-	 * set ino first. This RELEASE is paired with atomic_inc_not_zero in
++	 * set ino first. This barrier is paired with atomic_inc_not_zero in
+ 	 * kernfs_find_and_get_node_by_ino
+ 	 */
+-	atomic_set_release(&kn->count, 1);
++	smp_mb__before_atomic();
++	atomic_set(&kn->count, 1);
+ 	atomic_set(&kn->active, KN_DEACTIVATED_BIAS);
+ 	RB_CLEAR_NODE(&kn->rb);
+ 
+diff --git a/fs/kernfs/inode.c b/fs/kernfs/inode.c
+index 80cebcd94c90..3d47fd74cc8c 100644
+--- a/fs/kernfs/inode.c
++++ b/fs/kernfs/inode.c
+@@ -135,20 +135,15 @@ int kernfs_iop_setattr(struct dentry *dentry, struct iattr *iattr)
+ 	return error;
+ }
+ 
+-static int kernfs_node_setsecdata(struct kernfs_iattrs *attrs, void **secdata,
+-				  u32 *secdata_len)
++static int kernfs_node_setsecdata(struct kernfs_iattrs *attrs,
++				  struct lsm_context *cp)
+ {
+-	void *old_secdata;
+-	size_t old_secdata_len;
++	struct lsm_context old_context;
+ 
+-	old_secdata = attrs->ia_secdata;
+-	old_secdata_len = attrs->ia_secdata_len;
++	old_context = attrs->ia_context;
++	attrs->ia_context = *cp;
++	*cp = old_context;
+ 
+-	attrs->ia_secdata = *secdata;
+-	attrs->ia_secdata_len = *secdata_len;
+-
+-	*secdata = old_secdata;
+-	*secdata_len = old_secdata_len;
+ 	return 0;
+ }
+ 
+@@ -192,8 +187,7 @@ static void kernfs_refresh_inode(struct kernfs_node *kn, struct inode *inode)
+ 		 * persistent copy in kernfs_node.
+ 		 */
+ 		set_inode_attr(inode, &attrs->ia_iattr);
+-		security_inode_notifysecctx(inode, attrs->ia_secdata,
+-					    attrs->ia_secdata_len);
++		security_inode_notifysecctx(inode, &attrs->ia_context);
+ 	}
+ 
+ 	if (kernfs_type(kn) == KERNFS_DIR)
+@@ -349,8 +343,7 @@ static int kernfs_security_xattr_set(const struct xattr_handler *handler,
+ {
+ 	struct kernfs_node *kn = inode->i_private;
+ 	struct kernfs_iattrs *attrs;
+-	void *secdata;
+-	u32 secdata_len = 0;
++	struct lsm_context lc = { .context = NULL, .len = 0, };
+ 	int error;
+ 
+ 	attrs = kernfs_iattrs(kn);
+@@ -360,16 +353,16 @@ static int kernfs_security_xattr_set(const struct xattr_handler *handler,
+ 	error = security_inode_setsecurity(inode, suffix, value, size, flags);
+ 	if (error)
+ 		return error;
+-	error = security_inode_getsecctx(inode, &secdata, &secdata_len);
++	error = security_inode_getsecctx(inode, &lc);
+ 	if (error)
+ 		return error;
+ 
+ 	mutex_lock(&kernfs_mutex);
+-	error = kernfs_node_setsecdata(attrs, &secdata, &secdata_len);
++	error = kernfs_node_setsecdata(attrs, &lc);
+ 	mutex_unlock(&kernfs_mutex);
+ 
+-	if (secdata)
+-		security_release_secctx(secdata, secdata_len);
++	if (lc.context)
++		security_release_secctx(&lc);
+ 	return error;
+ }
+ 
+diff --git a/fs/kernfs/kernfs-internal.h b/fs/kernfs/kernfs-internal.h
+index 3d83b114bb08..54663e4d0866 100644
+--- a/fs/kernfs/kernfs-internal.h
++++ b/fs/kernfs/kernfs-internal.h
+@@ -15,13 +15,13 @@
+ #include <linux/fs.h>
+ #include <linux/mutex.h>
+ #include <linux/xattr.h>
++#include <linux/security.h>
+ 
+ #include <linux/kernfs.h>
+ 
+ struct kernfs_iattrs {
+ 	struct iattr		ia_iattr;
+-	void			*ia_secdata;
+-	u32			ia_secdata_len;
++    struct lsm_context      ia_context;
+ 
+ 	struct simple_xattrs	xattrs;
+ };
+diff --git a/fs/nfs/inode.c b/fs/nfs/inode.c
+index e4cd3a2fe698..8338c7a0e8ae 100644
+--- a/fs/nfs/inode.c
++++ b/fs/nfs/inode.c
+@@ -345,14 +345,13 @@ void nfs_setsecurity(struct inode *inode, struct nfs_fattr *fattr,
+ 		return;
+ 
+ 	if ((fattr->valid & NFS_ATTR_FATTR_V4_SECURITY_LABEL) && inode->i_security) {
+-		error = security_inode_notifysecctx(inode, label->label,
+-				label->len);
++        error = security_inode_notifysecctx(inode, &label->context);
+ 		if (error)
+ 			printk(KERN_ERR "%s() %s %d "
+ 					"security_inode_notifysecctx() %d\n",
+ 					__func__,
+-					(char *)label->label,
+-					label->len, error);
++					label->context.context,
++					label->context.len, error);
+ 		nfs_clear_label_invalid(inode);
+ 	}
+ }
+@@ -372,12 +371,12 @@ struct nfs4_label *nfs4_label_alloc(struct nfs_server *server, gfp_t flags)
+ 	if (label == NULL)
+ 		return ERR_PTR(-ENOMEM);
+ 
+-	label->label = kzalloc(NFS4_MAXLABELLEN, flags);
+-	if (label->label == NULL) {
++    label->context.context = kzalloc(NFS4_MAXLABELLEN, flags);
++    if (label->context.context == NULL) {
+ 		kfree(label);
+ 		return ERR_PTR(-ENOMEM);
+ 	}
+-	label->len = NFS4_MAXLABELLEN;
++    label->context.len = NFS4_MAXLABELLEN;
+ 
+ 	return label;
+ }
+diff --git a/fs/nfs/internal.h b/fs/nfs/internal.h
+index 8357ff69962f..e0cb86e70fb4 100644
+--- a/fs/nfs/internal.h
++++ b/fs/nfs/internal.h
+@@ -306,20 +306,20 @@ nfs4_label_copy(struct nfs4_label *dst, struct nfs4_label *src)
+ 	if (!dst || !src)
+ 		return NULL;
+ 
+-	if (src->len > NFS4_MAXLABELLEN)
++    if (src->context.len > NFS4_MAXLABELLEN)
+ 		return NULL;
+ 
+ 	dst->lfs = src->lfs;
+ 	dst->pi = src->pi;
+-	dst->len = src->len;
+-	memcpy(dst->label, src->label, src->len);
++    dst->context.len = src->context.len;
++    memcpy(dst->context.context, src->context.context, src->context.len);
+ 
+ 	return dst;
+ }
+ static inline void nfs4_label_free(struct nfs4_label *label)
+ {
+ 	if (label) {
+-		kfree(label->label);
++        kfree(label->context.context);
+ 		kfree(label);
+ 	}
+ 	return;
+diff --git a/fs/nfs/nfs4proc.c b/fs/nfs/nfs4proc.c
+index 7834b325394f..2c7c6cd8f579 100644
+--- a/fs/nfs/nfs4proc.c
++++ b/fs/nfs/nfs4proc.c
+@@ -122,7 +122,7 @@ nfs4_label_init_security(struct inode *dir, struct dentry *dentry,
+ 		return NULL;
+ 
+ 	err = security_dentry_init_security(dentry, sattr->ia_mode,
+-				&dentry->d_name, (void **)&label->label, &label->len);
++                &dentry->d_name, &label->context);
+ 	if (err == 0)
+ 		return label;
+ 
+@@ -131,8 +131,11 @@ nfs4_label_init_security(struct inode *dir, struct dentry *dentry,
+ static inline void
+ nfs4_label_release_security(struct nfs4_label *label)
+ {
+-	if (label)
+-		security_release_secctx(label->label, label->len);
++    struct lsm_context lc;  /* Scaffolding -Casey */
++
++    if (label) {
++        security_release_secctx(&label->context);
++    }
+ }
+ static inline u32 *nfs4_bitmask(struct nfs_server *server, struct nfs4_label *label)
+ {
+@@ -3532,7 +3535,9 @@ nfs4_atomic_open(struct inode *dir, struct nfs_open_context *ctx,
+ 		int open_flags, struct iattr *attr, int *opened)
+ {
+ 	struct nfs4_state *state;
+-	struct nfs4_label l = {0, 0, 0, NULL}, *label = NULL;
++    struct nfs4_label *label = NULL;
++    struct nfs4_label l = {0, 0,
++                    .context = { .context = NULL, .len = 0, }, };
+ 
+ 	label = nfs4_label_init_security(dir, ctx->dentry, attr, &l);
+ 
+@@ -5572,7 +5577,8 @@ static int _nfs4_get_security_label(struct inode *inode, void *buf,
+ {
+ 	struct nfs_server *server = NFS_SERVER(inode);
+ 	struct nfs_fattr fattr;
+-	struct nfs4_label label = {0, 0, buflen, buf};
++    struct nfs4_label label = {0, 0,
++                    .context = { .context = buf, .len = buflen, }, };
+ 
+ 	u32 bitmask[3] = { 0, 0, FATTR4_WORD2_SECURITY_LABEL };
+ 	struct nfs4_getattr_arg arg = {
+@@ -5598,7 +5604,7 @@ static int _nfs4_get_security_label(struct inode *inode, void *buf,
+ 		return ret;
+ 	if (!(fattr.valid & NFS_ATTR_FATTR_V4_SECURITY_LABEL))
+ 		return -ENOENT;
+-	if (buflen < label.len)
++	if (buflen < label.context.len)
+ 		return -ERANGE;
+ 	return 0;
+ }
+@@ -5691,8 +5697,8 @@ nfs4_set_security_label(struct inode *inode, const void *buf, size_t buflen)
+ 
+ 	ilabel.pi = 0;
+ 	ilabel.lfs = 0;
+-	ilabel.label = (char *)buf;
+-	ilabel.len = buflen;
++    ilabel.context.context = (char *)buf;
++    ilabel.context.len = buflen;
+ 
+ 	cred = rpc_lookup_cred();
+ 	if (IS_ERR(cred))
+diff --git a/fs/nfs/nfs4xdr.c b/fs/nfs/nfs4xdr.c
+index 1c0227c78a7b..32ca0d35d0f2 100644
+--- a/fs/nfs/nfs4xdr.c
++++ b/fs/nfs/nfs4xdr.c
+@@ -1140,7 +1140,7 @@ static void encode_attrs(struct xdr_stream *xdr, const struct iattr *iap,
+ 	}
+ 
+ 	if (label && (attrmask[2] & FATTR4_WORD2_SECURITY_LABEL)) {
+-		len += 4 + 4 + 4 + (XDR_QUADLEN(label->len) << 2);
++        len += 4 + 4 + 4 + (XDR_QUADLEN(label->context.len) << 2);
+ 		bmval[2] |= FATTR4_WORD2_SECURITY_LABEL;
+ 	}
+ 
+@@ -1174,8 +1174,9 @@ static void encode_attrs(struct xdr_stream *xdr, const struct iattr *iap,
+ 	if (label && (bmval[2] & FATTR4_WORD2_SECURITY_LABEL)) {
+ 		*p++ = cpu_to_be32(label->lfs);
+ 		*p++ = cpu_to_be32(label->pi);
+-		*p++ = cpu_to_be32(label->len);
+-		p = xdr_encode_opaque_fixed(p, label->label, label->len);
++        *p++ = cpu_to_be32(label->context.len);
++        p = xdr_encode_opaque_fixed(p, label->context.context,
++                                    label->context.len);
+ 	}
+ 	if (bmval[2] & FATTR4_WORD2_MODE_UMASK) {
+ 		*p++ = cpu_to_be32(iap->ia_mode & S_IALLUGO);
+@@ -4280,8 +4281,8 @@ static int decode_attr_security_label(struct xdr_stream *xdr, uint32_t *bitmap,
+ 			goto out_overflow;
+ 		if (len < NFS4_MAXLABELLEN) {
+ 			if (label) {
+-				memcpy(label->label, p, len);
+-				label->len = len;
++                memcpy(label->context.context, p, len);
++                label->context.len = len;
+ 				label->pi = pi;
+ 				label->lfs = lfs;
+ 				status = NFS_ATTR_FATTR_V4_SECURITY_LABEL;
+@@ -4291,9 +4292,10 @@ static int decode_attr_security_label(struct xdr_stream *xdr, uint32_t *bitmap,
+ 			printk(KERN_WARNING "%s: label too long (%u)!\n",
+ 					__func__, len);
+ 	}
+-	if (label && label->label)
++    if (label && label->context.context)
+ 		dprintk("%s: label=%s, len=%d, PI=%d, LFS=%d\n", __func__,
+-			(char *)label->label, label->len, label->pi, label->lfs);
++            (char *)label->context.context, label->context.len,
++            label->pi, label->lfs);
+ 	return status;
+ 
+ out_overflow:
+diff --git a/fs/nfsd/nfs4proc.c b/fs/nfsd/nfs4proc.c
+index f35aa9f88b5e..9f6edac91e42 100644
+--- a/fs/nfsd/nfs4proc.c
++++ b/fs/nfsd/nfs4proc.c
+@@ -53,12 +53,15 @@
+ static inline void
+ nfsd4_security_inode_setsecctx(struct svc_fh *resfh, struct xdr_netobj *label, u32 *bmval)
+ {
++    struct lsm_context lc;
+ 	struct inode *inode = d_inode(resfh->fh_dentry);
+ 	int status;
+ 
+ 	inode_lock(inode);
+-	status = security_inode_setsecctx(resfh->fh_dentry,
+-		label->data, label->len);
++    lsm_context_init(&lc);
++    lc.context = label->data;
++    lc.len = label->len;
++    status = security_inode_setsecctx(resfh->fh_dentry, &lc);
+ 	inode_unlock(inode);
+ 
+ 	if (status)
+diff --git a/fs/nfsd/nfs4xdr.c b/fs/nfsd/nfs4xdr.c
+index db0beefe65ec..999fc14b83ee 100644
+--- a/fs/nfsd/nfs4xdr.c
++++ b/fs/nfsd/nfs4xdr.c
+@@ -2414,8 +2414,7 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
+ 	int err;
+ 	struct nfs4_acl *acl = NULL;
+ #ifdef CONFIG_NFSD_V4_SECURITY_LABEL
+-	void *context = NULL;
+-	int contextlen;
++    struct lsm_context lc = { .context = NULL, .len = 0, };
+ #endif
+ 	bool contextsupport = false;
+ 	struct nfsd4_compoundres *resp = rqstp->rq_resp;
+@@ -2472,8 +2471,7 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
+ 	if ((bmval2 & FATTR4_WORD2_SECURITY_LABEL) ||
+ 	     bmval0 & FATTR4_WORD0_SUPPORTED_ATTRS) {
+ 		if (exp->ex_flags & NFSEXP_SECURITY_LABEL)
+-			err = security_inode_getsecctx(d_inode(dentry),
+-						&context, &contextlen);
++            err = security_inode_getsecctx(d_inode(dentry), &lc);
+ 		else
+ 			err = -EOPNOTSUPP;
+ 		contextsupport = (err == 0);
+@@ -2903,8 +2901,8 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
+ 
+ #ifdef CONFIG_NFSD_V4_SECURITY_LABEL
+ 	if (bmval2 & FATTR4_WORD2_SECURITY_LABEL) {
+-		status = nfsd4_encode_security_label(xdr, rqstp, context,
+-								contextlen);
++        status = nfsd4_encode_security_label(xdr, rqstp, lc.context,
++                                lc.len);
+ 		if (status)
+ 			goto out;
+ 	}
+@@ -2916,8 +2914,8 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
+ 
+ out:
+ #ifdef CONFIG_NFSD_V4_SECURITY_LABEL
+-	if (context)
+-		security_release_secctx(context, contextlen);
++	if (lc.context)
++        security_release_secctx(&lc);
+ #endif /* CONFIG_NFSD_V4_SECURITY_LABEL */
+ 	kfree(acl);
+ 	if (tempfh) {
+diff --git a/fs/nfsd/vfs.c b/fs/nfsd/vfs.c
+index 4fe8db314950..e4323cbf6ed0 100644
+--- a/fs/nfsd/vfs.c
++++ b/fs/nfsd/vfs.c
+@@ -531,6 +531,7 @@ __be32 nfsd4_set_nfs4_label(struct svc_rqst *rqstp, struct svc_fh *fhp,
+ 	__be32 error;
+ 	int host_error;
+ 	struct dentry *dentry;
++    struct lsm_context lc;
+ 
+ 	error = fh_verify(rqstp, fhp, 0 /* S_IFREG */, NFSD_MAY_SATTR);
+ 	if (error)
+@@ -539,7 +540,11 @@ __be32 nfsd4_set_nfs4_label(struct svc_rqst *rqstp, struct svc_fh *fhp,
+ 	dentry = fhp->fh_dentry;
+ 
+ 	inode_lock(d_inode(dentry));
+-	host_error = security_inode_setsecctx(dentry, label->data, label->len);
++    lsm_context_init(&lc);
++
++    lc.context = label->data;
++    lc.len = label->len;
++    host_error = security_inode_setsecctx(dentry, &lc);
+ 	inode_unlock(d_inode(dentry));
+ 	return nfserrno(host_error);
+ }
+diff --git a/fs/proc/base.c b/fs/proc/base.c
+index 0deea40f0a80..6ce850165d59 100644
+--- a/fs/proc/base.c
++++ b/fs/proc/base.c
+@@ -143,6 +143,11 @@ struct pid_entry {
+ 	NOD(NAME, (S_IFREG|(MODE)), 			\
+ 		NULL, &proc_single_file_operations,	\
+ 		{ .proc_show = show } )
++#define ATTR(LSM, NAME, MODE)                          \
++       NOD(NAME, (S_IFREG|(MODE)),                     \
++               NULL, &proc_pid_attr_operations,        \
++               { .lsm = LSM })
++
+ 
+ #ifdef CONFIG_SECURITY_CHROMIUMOS_READONLY_PROC_SELF_MEM
+ # define PROC_PID_MEM_MODE S_IRUSR
+@@ -2597,7 +2602,7 @@ static ssize_t proc_pid_attr_read(struct file * file, char __user * buf,
+ 	if (!task)
+ 		return -ESRCH;
+ 
+-	length = security_getprocattr(task,
++    length = security_getprocattr(task, PROC_I(inode)->op.lsm,
+ 				      (char*)file->f_path.dentry->d_name.name,
+ 				      &p);
+ 	put_task_struct(task);
+@@ -2651,7 +2656,9 @@ static ssize_t proc_pid_attr_write(struct file * file, const char __user * buf,
+ 	if (rv < 0)
+ 		goto out_free;
+ 
+-	rv = security_setprocattr(file->f_path.dentry->d_name.name, page, count);
++    rv = security_setprocattr(PROC_I(inode)->op.lsm,
++                              file->f_path.dentry->d_name.name, page,
++                              count);
+ 	mutex_unlock(&current->signal->cred_guard_mutex);
+ out_free:
+ 	kfree(page);
+@@ -2665,13 +2672,55 @@ static const struct file_operations proc_pid_attr_operations = {
+ 	.llseek		= generic_file_llseek,
+ };
+ 
++#define LSM_DIR_OPS(LSM) \
++static int proc_##LSM##_attr_dir_iterate(struct file *filp, \
++                            struct dir_context *ctx) \
++{ \
++       return proc_pident_readdir(filp, ctx, \
++                                  LSM##_attr_dir_stuff, \
++                                  ARRAY_SIZE(LSM##_attr_dir_stuff)); \
++} \
++\
++static const struct file_operations proc_##LSM##_attr_dir_ops = { \
++       .read           = generic_read_dir, \
++       .iterate        = proc_##LSM##_attr_dir_iterate, \
++       .llseek         = default_llseek, \
++}; \
++\
++static struct dentry *proc_##LSM##_attr_dir_lookup(struct inode *dir, \
++                               struct dentry *dentry, unsigned int flags) \
++{ \
++       return proc_pident_lookup(dir, dentry, \
++                                 LSM##_attr_dir_stuff, \
++                                 ARRAY_SIZE(LSM##_attr_dir_stuff)); \
++} \
++\
++static const struct inode_operations proc_##LSM##_attr_dir_inode_ops = { \
++       .lookup         = proc_##LSM##_attr_dir_lookup, \
++       .getattr        = pid_getattr, \
++       .setattr        = proc_setattr, \
++}
++
++#ifdef CONFIG_SECURITY_SMACK
++static const struct pid_entry smack_attr_dir_stuff[] = {
++       ATTR("smack", "current",        0666),
++};
++LSM_DIR_OPS(smack);
++#endif
++
+ static const struct pid_entry attr_dir_stuff[] = {
+-	REG("current",    S_IRUGO|S_IWUGO, proc_pid_attr_operations),
+-	REG("prev",       S_IRUGO,	   proc_pid_attr_operations),
+-	REG("exec",       S_IRUGO|S_IWUGO, proc_pid_attr_operations),
+-	REG("fscreate",   S_IRUGO|S_IWUGO, proc_pid_attr_operations),
+-	REG("keycreate",  S_IRUGO|S_IWUGO, proc_pid_attr_operations),
+-	REG("sockcreate", S_IRUGO|S_IWUGO, proc_pid_attr_operations),
++    ATTR(NULL, "current",           0666),
++    ATTR(NULL, "prev",              0444),
++    ATTR(NULL, "exec",              0666),
++    ATTR(NULL, "fscreate",          0666),
++    ATTR(NULL, "keycreate",         0666),
++    ATTR(NULL, "sockcreate",        0666),
++    ATTR(NULL, "display",           0666),
++#ifdef CONFIG_SECURITY_SMACK
++       DIR("smack",                    0555,
++           proc_smack_attr_dir_inode_ops, proc_smack_attr_dir_ops),
++#endif
++
+ };
+ 
+ static int proc_attr_dir_readdir(struct file *file, struct dir_context *ctx)
+diff --git a/fs/proc/internal.h b/fs/proc/internal.h
+index b7202a7cd430..43dbe973bf06 100644
+--- a/fs/proc/internal.h
++++ b/fs/proc/internal.h
+@@ -82,6 +82,7 @@ union proc_op {
+ 	int (*proc_show)(struct seq_file *m,
+ 		struct pid_namespace *ns, struct pid *pid,
+ 		struct task_struct *task);
++    const char *lsm;
+ };
+ 
+ 
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index dd38c97933f1..7eec7b93e843 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -203,6 +203,15 @@
+ #define EARLYCON_TABLE()
+ #endif
+ 
++#ifdef CONFIG_SECURITY
++#define LSM_TABLE() . = ALIGN(8);                   \
++            __start_lsm_info = .;               \
++            KEEP(*(.lsm_info.init))             \
++            __end_lsm_info = .;
++#else
++#define LSM_TABLE()
++#endif
++
+ #define ___OF_TABLE(cfg, name)	_OF_TABLE_##cfg(name)
+ #define __OF_TABLE(cfg, name)	___OF_TABLE(cfg, name)
+ #define OF_TABLE(cfg, name)	__OF_TABLE(IS_ENABLED(cfg), name)
+@@ -473,13 +482,6 @@
+ #define RODATA          RO_DATA_SECTION(4096)
+ #define RO_DATA(align)  RO_DATA_SECTION(align)
+ 
+-#define SECURITY_INIT							\
+-	.security_initcall.init : AT(ADDR(.security_initcall.init) - LOAD_OFFSET) { \
+-		__security_initcall_start = .;				\
+-		KEEP(*(.security_initcall.init))			\
+-		__security_initcall_end = .;				\
+-	}
+-
+ /*
+  * .text section. Map to function alignment to avoid address changes
+  * during second ld run in second ld pass when generating System.map
+@@ -604,7 +606,8 @@
+ 	IRQCHIP_OF_MATCH_TABLE()					\
+ 	ACPI_PROBE_TABLE(irqchip)					\
+ 	ACPI_PROBE_TABLE(timer)						\
+-	EARLYCON_TABLE()
++	EARLYCON_TABLE()                        \
++    LSM_TABLE()
+ 
+ #define INIT_TEXT							\
+ 	*(.init.text .init.text.*)					\
+@@ -793,11 +796,6 @@
+ 		KEEP(*(.con_initcall.init))				\
+ 		__con_initcall_end = .;
+ 
+-#define SECURITY_INITCALL						\
+-		__security_initcall_start = .;				\
+-		KEEP(*(.security_initcall.init))			\
+-		__security_initcall_end = .;
+-
+ #ifdef CONFIG_BLK_DEV_INITRD
+ #define INIT_RAM_FS							\
+ 	. = ALIGN(4);							\
+@@ -964,7 +962,6 @@
+ 		INIT_SETUP(initsetup_align)				\
+ 		INIT_CALLS						\
+ 		CON_INITCALL						\
+-		SECURITY_INITCALL					\
+ 		INIT_RAM_FS						\
+ 	}
+ 
+diff --git a/include/linux/cred.h b/include/linux/cred.h
+index 1dc351d8548b..19655d4b0d9a 100644
+--- a/include/linux/cred.h
++++ b/include/linux/cred.h
+@@ -23,6 +23,7 @@
+ 
+ struct cred;
+ struct inode;
++struct lsm_export;
+ 
+ /*
+  * COW Supplementary groups list
+@@ -170,7 +171,7 @@ extern const struct cred *override_creds(const struct cred *);
+ extern void revert_creds(const struct cred *);
+ extern struct cred *prepare_kernel_cred(struct task_struct *);
+ extern int change_create_files_as(struct cred *, struct inode *);
+-extern int set_security_override(struct cred *, u32);
++extern int set_security_override(struct cred *, struct lsm_export *);
+ extern int set_security_override_from_ctx(struct cred *, const char *);
+ extern int set_create_files_as(struct cred *, struct inode *);
+ extern void __init cred_init(void);
+diff --git a/include/linux/lsm_hooks.h b/include/linux/lsm_hooks.h
+index c7a692dad1a0..6fc49996be14 100644
+--- a/include/linux/lsm_hooks.h
++++ b/include/linux/lsm_hooks.h
+@@ -150,8 +150,7 @@
+  *	@dentry dentry to use in calculating the context.
+  *	@mode mode used to determine resource type.
+  *	@name name of the last path component used to create file
+- *	@ctx pointer to place the pointer to the resulting context in.
+- *	@ctxlen point to place the length of the resulting context.
++ *	@cp pointer to place the pointer to the resulting context in.
+  * @dentry_create_files_as:
+  *	Compute a context for a dentry as the inode is not yet available
+  *	and set that context in passed in creds so that new files are
+@@ -409,7 +408,7 @@
+  * @inode_getsecid:
+  *	Get the secid associated with the node.
+  *	@inode contains a pointer to the inode.
+- *	@secid contains a pointer to the location where result will be saved.
++ *	@data contains a pointer to the location where result will be saved.
+  *	In case of failure, @secid will be set to zero.
+  * @inode_copy_up:
+  *	A file is about to be copied up from lower layer to upper layer of
+@@ -556,12 +555,13 @@
+  *	Transfer data from original creds to new creds
+  * @cred_getsecid:
+  *	Retrieve the security identifier of the cred structure @c
+- *	@c contains the credentials, secid will be placed into @secid.
++ *	@c contains the credentials
++ *	@l contains a pointer to the location where result will be saved.
+  *	In case of failure, @secid will be set to zero.
+  * @kernel_act_as:
+  *	Set the credentials for a kernel service to act as (subjective context).
+  *	@new points to the credentials to be modified.
+- *	@secid specifies the security ID to be set
++ *	@l specifies the security data to be set
+  *	The current task must be the one that nominated @secid.
+  *	Return 0 if successful.
+  * @kernel_create_files_as:
+@@ -621,7 +621,7 @@
+  *	Return 0 if permission is granted.
+  * @task_getsecid:
+  *	Retrieve the security identifier of the process @p.
+- *	@p contains the task_struct for the process and place is into @secid.
++ *	@p contains the task_struct for the process and place is into @l.
+  *	In case of failure, @secid will be set to zero.
+  *
+  * @task_setnice:
+@@ -672,7 +672,7 @@
+  *	Return 0 if permission is granted.
+  * @task_kill:
+  *	Check permission before sending signal @sig to @p.  @info can be NULL,
+- *	the constant 1, or a pointer to a siginfo structure.  If @info is 1 or
++ *	the constant 1, or a pointer to a kernel_siginfo structure.  If @info is 1 or
+  *	SI_FROMKERNEL(info) is true, then the signal should be viewed as coming
+  *	from the kernel and should typically be permitted.
+  *	SIGIO signals are handled separately by the send_sigiotask hook in
+@@ -683,9 +683,6 @@
+  *	@cred contains the cred of the process where the signal originated, or
+  *	NULL if the current task is the originator.
+  *	Return 0 if permission is granted.
+- * @task_exit:
+- *      Called early when a task is exiting before all state is lost.
+- *      @p contains the task_struct for process.
+  * @task_prctl:
+  *	Check permission before performing a process control operation on the
+  *	current process.
+@@ -867,9 +864,9 @@
+  *	the IP_PASSSEC option via getsockopt.  It can then retrieve the
+  *	security state returned by this hook for a packet via the SCM_SECURITY
+  *	ancillary message type.
++ *	@sock is the socket
+  *	@skb is the skbuff for the packet being queried
+- *	@secdata is a pointer to a buffer in which to copy the security data
+- *	@seclen is the maximum length for @secdata
++ *	@l is a pointer to a buffer in which to copy the security data
+  *	Return 0 on success, error on failure.
+  * @sk_alloc_security:
+  *	Allocate and attach a security structure to the sk->sk_security field,
+@@ -879,7 +876,7 @@
+  * @sk_clone_security:
+  *	Clone/copy security structure.
+  * @sk_getsecid:
+- *	Retrieve the LSM-specific secid for the sock to enable caching
++ *	Retrieve the LSM exported data for the sock to enable caching
+  *	of network authorizations.
+  * @sock_graft:
+  *	Sets the socket's isec sid to the sock's sid.
+@@ -1082,7 +1079,7 @@
+  * @ipc_getsecid:
+  *	Get the secid associated with the ipc object.
+  *	@ipcp contains the kernel IPC permission structure.
+- *	@secid contains a pointer to the location where result will be saved.
++ *	@l contains a pointer to the location where result will be saved.
+  *	In case of failure, @secid will be set to zero.
+  *
+  * Security hooks for individual messages held in System V IPC message queues
+@@ -1273,7 +1270,7 @@
+  *	@cred contains the credentials to use.
+  *	@ns contains the user namespace we want the capability in
+  *	@cap contains the capability <include/linux/capability.h>.
+- *	@opts contains options for the capable check <include/linux/security.h>
++ *	@audit contains whether to write an audit message or not
+  *	Return 0 if the capability is granted for @tsk.
+  * @syslog:
+  *	Check permission before accessing the kernel message ring or changing
+@@ -1308,19 +1305,13 @@
+  *	This does mean that the length could change between calls to check the
+  *	length and the next call which actually allocates and returns the
+  *	secdata.
+- *	@secid contains the security ID.
+- *	@secdata contains the pointer that stores the converted security
++ *	@l points to the security information.
++ *	@cp contains the pointer that stores the converted security
+  *	context.
+- *	@seclen pointer which contains the length of the data
+  * @secctx_to_secid:
+- *	Convert security context to secid.
+- *	@secid contains the pointer to the generated security ID.
+- *	@secdata contains the security context.
+- *
+- * @release_secctx:
+- *	Release the security context.
+- *	@secdata contains the security context.
+- *	@seclen contains the length of the security context.
++ *	Convert security context to exported lsm data.
++ *	@cp contains the security context.
++ *	@l contains the pointer to the generated security data.
+  *
+  * Security hooks for Audit
+  *
+@@ -1343,7 +1334,7 @@
+  * @audit_rule_match:
+  *	Determine if given @secid matches a rule previously approved
+  *	by @audit_rule_known.
+- *	@secid contains the security id in question.
++ *	@l points to the security data in question.
+  *	@field contains the field which relates to current LSM.
+  *	@op contains the operator that will be used for matching.
+  *	@rule points to the audit rule that will be checked against.
+@@ -1370,8 +1361,7 @@
+  *	Must be called with inode->i_mutex locked.
+  *
+  *	@inode we wish to set the security context of.
+- *	@ctx contains the string which we wish to set in the inode.
+- *	@ctxlen contains the length of @ctx.
++ *	@cp contains the string which we wish to set in the inode.
+  *
+  * @inode_setsecctx:
+  *	Change the security context of an inode.  Updates the
+@@ -1385,16 +1375,14 @@
+  *	Must be called with inode->i_mutex locked.
+  *
+  *	@dentry contains the inode we wish to set the security context of.
+- *	@ctx contains the string which we wish to set in the inode.
+- *	@ctxlen contains the length of @ctx.
++ *	@cp contains the string which we wish to set in the inode.
+  *
+  * @inode_getsecctx:
+- *	On success, returns 0 and fills out @ctx and @ctxlen with the security
++ *	On success, returns 0 and fills out @cp with the security
+  *	context for the given @inode.
+  *
+  *	@inode we wish to get the security context of.
+- *	@ctx is a pointer in which to place the allocated security context.
+- *	@ctxlen points to the place to put the length of @ctx.
++ *	@cp is a pointer in which to place the allocated security context.
+  *
+  * Security hooks for using the eBPF maps and programs functionalities through
+  * eBPF syscalls.
+@@ -1449,10 +1437,8 @@ union security_list_options {
+ 			const kernel_cap_t *effective,
+ 			const kernel_cap_t *inheritable,
+ 			const kernel_cap_t *permitted);
+-	int (*capable)(const struct cred *cred,
+-			struct user_namespace *ns,
+-			int cap,
+-			unsigned int opts);
++	int (*capable)(const struct cred *cred, struct user_namespace *ns,
++			int cap, int audit);
+ 	int (*quotactl)(int cmds, int type, int id, struct super_block *sb);
+ 	int (*quota_on)(struct dentry *dentry);
+ 	int (*syslog)(int type);
+@@ -1485,8 +1471,8 @@ union security_list_options {
+ 					unsigned long *set_kern_flags);
+ 	int (*sb_parse_opts_str)(char *options, struct security_mnt_opts *opts);
+ 	int (*dentry_init_security)(struct dentry *dentry, int mode,
+-					const struct qstr *name, void **ctx,
+-					u32 *ctxlen);
++					const struct qstr *name,
++					struct lsm_context *cp);
+ 	int (*dentry_create_files_as)(struct dentry *dentry, int mode,
+ 					struct qstr *name,
+ 					const struct cred *old,
+@@ -1557,7 +1543,7 @@ union security_list_options {
+ 					int flags);
+ 	int (*inode_listsecurity)(struct inode *inode, char *buffer,
+ 					size_t buffer_size);
+-	void (*inode_getsecid)(struct inode *inode, u32 *secid);
++	void (*inode_getsecid)(struct inode *inode, struct lsm_export *data);
+ 	int (*inode_copy_up)(struct dentry *src, struct cred **new);
+ 	int (*inode_copy_up_xattr)(const char *name);
+ 
+@@ -1587,8 +1573,8 @@ union security_list_options {
+ 	int (*cred_prepare)(struct cred *new, const struct cred *old,
+ 				gfp_t gfp);
+ 	void (*cred_transfer)(struct cred *new, const struct cred *old);
+-	void (*cred_getsecid)(const struct cred *c, u32 *secid);
+-	int (*kernel_act_as)(struct cred *new, u32 secid);
++	void (*cred_getsecid)(const struct cred *c, struct lsm_export *l);
++	int (*kernel_act_as)(struct cred *new, struct lsm_export *l);
+ 	int (*kernel_create_files_as)(struct cred *new, struct inode *inode);
+ 	int (*kernel_module_request)(char *kmod_name);
+ 	int (*kernel_load_data)(enum kernel_load_data_id id);
+@@ -1600,7 +1586,7 @@ union security_list_options {
+ 	int (*task_setpgid)(struct task_struct *p, pid_t pgid);
+ 	int (*task_getpgid)(struct task_struct *p);
+ 	int (*task_getsid)(struct task_struct *p);
+-	void (*task_getsecid)(struct task_struct *p, u32 *secid);
++	void (*task_getsecid)(struct task_struct *p, struct lsm_export *l);
+ 	int (*task_setnice)(struct task_struct *p, int nice);
+ 	int (*task_setioprio)(struct task_struct *p, int ioprio);
+ 	int (*task_getioprio)(struct task_struct *p);
+@@ -1613,13 +1599,12 @@ union security_list_options {
+ 	int (*task_movememory)(struct task_struct *p);
+ 	int (*task_kill)(struct task_struct *p, struct siginfo *info,
+ 				int sig, const struct cred *cred);
+-	void (*task_exit)(struct task_struct *p);
+ 	int (*task_prctl)(int option, unsigned long arg2, unsigned long arg3,
+ 				unsigned long arg4, unsigned long arg5);
+ 	void (*task_to_inode)(struct task_struct *p, struct inode *inode);
+ 
+ 	int (*ipc_permission)(struct kern_ipc_perm *ipcp, short flag);
+-	void (*ipc_getsecid)(struct kern_ipc_perm *ipcp, u32 *secid);
++	void (*ipc_getsecid)(struct kern_ipc_perm *ipcp, struct lsm_export *l);
+ 
+ 	int (*msg_msg_alloc_security)(struct msg_msg *msg);
+ 	void (*msg_msg_free_security)(struct msg_msg *msg);
+@@ -1655,14 +1640,14 @@ union security_list_options {
+ 	int (*getprocattr)(struct task_struct *p, char *name, char **value);
+ 	int (*setprocattr)(const char *name, void *value, size_t size);
+ 	int (*ismaclabel)(const char *name);
+-	int (*secid_to_secctx)(u32 secid, char **secdata, u32 *seclen);
+-	int (*secctx_to_secid)(const char *secdata, u32 seclen, u32 *secid);
+-	void (*release_secctx)(char *secdata, u32 seclen);
++	int (*secid_to_secctx)(struct lsm_export *l, struct lsm_context *cp);
++	int (*secctx_to_secid)(const struct lsm_context *cp,
++				struct lsm_export *l);
+ 
+ 	void (*inode_invalidate_secctx)(struct inode *inode);
+-	int (*inode_notifysecctx)(struct inode *inode, void *ctx, u32 ctxlen);
+-	int (*inode_setsecctx)(struct dentry *dentry, void *ctx, u32 ctxlen);
+-	int (*inode_getsecctx)(struct inode *inode, void **ctx, u32 *ctxlen);
++	int (*inode_notifysecctx)(struct inode *inode, struct lsm_context *cp);
++	int (*inode_setsecctx)(struct dentry *dentry, struct lsm_context *cp);
++	int (*inode_getsecctx)(struct inode *inode, struct lsm_context *cp);
+ 
+ #ifdef CONFIG_SECURITY_NETWORK
+ 	int (*unix_stream_connect)(struct sock *sock, struct sock *other,
+@@ -1693,7 +1678,8 @@ union security_list_options {
+ 					char __user *optval,
+ 					int __user *optlen, unsigned len);
+ 	int (*socket_getpeersec_dgram)(struct socket *sock,
+-					struct sk_buff *skb, u32 *secid);
++					struct sk_buff *skb,
++					struct lsm_export *l);
+ 	int (*sk_alloc_security)(struct sock *sk, int family, gfp_t priority);
+ 	void (*sk_free_security)(struct sock *sk);
+ 	void (*sk_clone_security)(const struct sock *sk, struct sock *newsk);
+@@ -1768,8 +1754,8 @@ union security_list_options {
+ 	int (*audit_rule_init)(u32 field, u32 op, char *rulestr,
+ 				void **lsmrule);
+ 	int (*audit_rule_known)(struct audit_krule *krule);
+-	int (*audit_rule_match)(u32 secid, u32 field, u32 op, void *lsmrule,
+-				struct audit_context *actx);
++	int (*audit_rule_match)(struct lsm_export *l, u32 field, u32 op,
++				void *lsmrule, struct audit_context *actx);
+ 	void (*audit_rule_free)(void *lsmrule);
+ #endif /* CONFIG_AUDIT */
+ 
+@@ -1901,7 +1887,6 @@ struct security_hook_heads {
+ 	struct hlist_head task_getscheduler;
+ 	struct hlist_head task_movememory;
+ 	struct hlist_head task_kill;
+-	struct hlist_head task_exit;
+ 	struct hlist_head task_prctl;
+ 	struct hlist_head task_to_inode;
+ 	struct hlist_head ipc_permission;
+@@ -1931,7 +1916,6 @@ struct security_hook_heads {
+ 	struct hlist_head ismaclabel;
+ 	struct hlist_head secid_to_secctx;
+ 	struct hlist_head secctx_to_secid;
+-	struct hlist_head release_secctx;
+ 	struct hlist_head inode_invalidate_secctx;
+ 	struct hlist_head inode_notifysecctx;
+ 	struct hlist_head inode_setsecctx;
+@@ -2031,6 +2015,34 @@ struct security_hook_list {
+ 	char				*lsm;
+ } __randomize_layout;
+ 
++/*
++ * The set of hooks that may be selected for a specific module.
++ */
++struct lsm_one_hooks {
++	char *lsm;
++	union security_list_options secid_to_secctx;
++	union security_list_options secctx_to_secid;
++	union security_list_options socket_getpeersec_stream;
++	union security_list_options secmark_relabel_packet;
++	union security_list_options secmark_refcount_inc;
++	union security_list_options secmark_refcount_dec;
++};
++
++/*
++ * Security blob size or offset data.
++ */
++struct lsm_blob_sizes {
++	int	lbs_cred;
++	int	lbs_file;
++	int	lbs_inode;
++	int	lbs_sock;
++	int	lbs_superblock;
++	int	lbs_ipc;
++	int	lbs_key;
++	int	lbs_msg_msg;
++	int	lbs_task;
++};
++
+ /*
+  * Initializing a security_hook_list structure takes
+  * up a lot of space in a source file. This macro takes
+@@ -2046,6 +2058,30 @@ extern char *lsm_names;
+ extern void security_add_hooks(struct security_hook_list *hooks, int count,
+ 				char *lsm);
+ 
++#define LSM_FLAG_LEGACY_MAJOR	BIT(0)
++#define LSM_FLAG_EXCLUSIVE	BIT(1)
++
++enum lsm_order {
++	LSM_ORDER_FIRST = -1,	/* This is only for capabilities. */
++	LSM_ORDER_MUTABLE = 0,
++};
++
++struct lsm_info {
++	const char *name;	/* Required. */
++	enum lsm_order order;	/* Optional: default is LSM_ORDER_MUTABLE */
++	unsigned long flags;	/* Optional: flags describing LSM */
++	int *enabled;		/* Optional: controlled by CONFIG_LSM */
++	int (*init)(void);	/* Required. */
++	struct lsm_blob_sizes *blobs; /* Optional: for blob sharing. */
++};
++
++extern struct lsm_info __start_lsm_info[], __end_lsm_info[];
++
++#define DEFINE_LSM(lsm)							\
++	static struct lsm_info __lsm_##lsm				\
++		__used __section(.lsm_info.init)			\
++		__aligned(sizeof(unsigned long))
++
+ #ifdef CONFIG_SECURITY_SELINUX_DISABLE
+ /*
+  * Assuring the safety of deleting a security module is up to
+@@ -2076,17 +2112,11 @@ static inline void security_delete_hooks(struct security_hook_list *hooks,
+ #define __lsm_ro_after_init	__ro_after_init
+ #endif /* CONFIG_SECURITY_WRITABLE_HOOKS */
+ 
+-extern int __init security_module_enable(const char *module);
+-extern void __init capability_add_hooks(void);
+-#ifdef CONFIG_SECURITY_YAMA
+-extern void __init yama_add_hooks(void);
+-#else
+-static inline void __init yama_add_hooks(void) { }
+-#endif
+-#ifdef CONFIG_SECURITY_LOADPIN
+-void __init loadpin_add_hooks(void);
+-#else
+-static inline void loadpin_add_hooks(void) { };
++extern int lsm_inode_alloc(struct inode *inode);
++
++#ifdef CONFIG_SECURITY
++void __init lsm_early_cred(struct cred *cred);
++void __init lsm_early_task(struct task_struct *task);
+ #endif
+ 
+ #endif /* ! __LINUX_LSM_HOOKS_H */
+diff --git a/include/linux/nfs4.h b/include/linux/nfs4.h
+index 1b06f0b28453..e88cb3b5933d 100644
+--- a/include/linux/nfs4.h
++++ b/include/linux/nfs4.h
+@@ -15,6 +15,7 @@
+ 
+ #include <linux/list.h>
+ #include <linux/uidgid.h>
++#include <linux/security.h>
+ #include <uapi/linux/nfs4.h>
+ 
+ enum nfs4_acl_whotype {
+@@ -43,10 +44,9 @@ struct nfs4_acl {
+ #define NFS4_MAXLABELLEN	2048
+ 
+ struct nfs4_label {
+-	uint32_t	lfs;
+-	uint32_t	pi;
+-	u32		len;
+-	char	*label;
++    uint32_t                lfs;
++    uint32_t                pi;
++    struct lsm_context      context;
+ };
+ 
+ typedef struct { char data[NFS4_VERIFIER_SIZE]; } nfs4_verifier;
+diff --git a/include/linux/security.h b/include/linux/security.h
+index 2ffff66a8e1a..6f2ddaed4c84 100644
+--- a/include/linux/security.h
++++ b/include/linux/security.h
+@@ -35,7 +35,6 @@
+ struct linux_binprm;
+ struct cred;
+ struct rlimit;
+-struct siginfo;
+ struct sembuf;
+ struct kern_ipc_perm;
+ struct audit_context;
+@@ -54,12 +53,9 @@ struct xattr;
+ struct xfrm_sec_ctx;
+ struct mm_struct;
+ 
+-/* Default (no) options for the capable function */
+-#define CAP_OPT_NONE 0x0
+ /* If capable should audit the security request */
+-#define CAP_OPT_NOAUDIT BIT(1)
+-/* If capable is being called by a setid function */
+-#define CAP_OPT_INSETID BIT(2)
++#define SECURITY_CAP_NOAUDIT 0
++#define SECURITY_CAP_AUDIT 1
+ 
+ /* LSM Agnostic defines for sb_set_mnt_opts */
+ #define SECURITY_LSM_NATIVE_LABELS	1
+@@ -68,14 +64,86 @@ struct ctl_table;
+ struct audit_krule;
+ struct user_namespace;
+ struct timezone;
++struct sk_buff;
+ 
+ enum lsm_event {
+ 	LSM_POLICY_CHANGE,
+ };
+ 
++/* Data exported by the security modules */
++struct lsm_export {
++	u32	selinux;
++	u32	smack;
++	u32	apparmor;
++	u32	flags;
++};
++#define LSM_EXPORT_NONE		0x00000000
++#define LSM_EXPORT_SELINUX	0x00000001
++#define LSM_EXPORT_SMACK	0x00000002
++#define LSM_EXPORT_APPARMOR	0x00000004
++#define LSM_EXPORT_LENGTH	0x80000000	/* Only the length required */
++
++static inline void lsm_export_init(struct lsm_export *l)
++{
++	memset(l, 0, sizeof(*l));
++}
++
++static inline bool lsm_export_any(struct lsm_export *l)
++{
++	return (((l->flags & LSM_EXPORT_SELINUX) && l->selinux) ||
++		((l->flags & LSM_EXPORT_SMACK) && l->smack) ||
++		((l->flags & LSM_EXPORT_APPARMOR) && l->apparmor));
++}
++
++static inline bool lsm_export_equal(struct lsm_export *l, struct lsm_export *m)
++{
++	if (l->flags != m->flags || l->flags == LSM_EXPORT_NONE)
++		return false;
++	if (l->flags & LSM_EXPORT_SELINUX &&
++	    (l->selinux != m->selinux || l->selinux == 0))
++		return false;
++	if (l->flags & LSM_EXPORT_SMACK &&
++	    (l->smack != m->smack || l->smack == 0))
++		return false;
++	if (l->flags & LSM_EXPORT_APPARMOR &&
++	    (l->apparmor != m->apparmor || l->apparmor == 0))
++		return false;
++	return true;
++}
++
++/*
++ * After calling security_secctx_to_secid() one, and only one
++ * of the LSM fields will be set in the lsm_export. Return
++ * whichever one was set. Used to supply secmarks.
++ */
++static inline u32 lsm_export_one_secid(struct lsm_export *l)
++{
++	if (l->flags & LSM_EXPORT_SELINUX)
++		return l->selinux;
++	if (l->flags & LSM_EXPORT_SMACK)
++		return l->smack;
++	if (l->flags & LSM_EXPORT_APPARMOR)
++		return l->apparmor;
++	return 0;
++}
++
++extern struct lsm_export *lsm_export_skb(struct sk_buff *skb);
++
++/* Text representation of LSM specific security information - a "context" */
++struct lsm_context {
++	char	*context;
++	u32	len;
++	void	(*release)(struct lsm_context *cp); /* frees .context */
++};
++
++static inline void lsm_context_init(struct lsm_context *cp)
++{
++	memset(cp, 0, sizeof(*cp));
++}
++
+ /* These functions are in security/commoncap.c */
+ extern int cap_capable(const struct cred *cred, struct user_namespace *ns,
+-		       int cap, unsigned int opts);
++		       int cap, int audit);
+ extern int cap_settime(const struct timespec64 *ts, const struct timezone *tz);
+ extern int cap_ptrace_access_check(struct task_struct *child, unsigned int mode);
+ extern int cap_ptrace_traceme(struct task_struct *parent);
+@@ -104,7 +172,6 @@ extern int cap_task_setnice(struct task_struct *p, int nice);
+ extern int cap_vm_enough_memory(struct mm_struct *mm, long pages);
+ 
+ struct msghdr;
+-struct sk_buff;
+ struct sock;
+ struct sockaddr;
+ struct socket;
+@@ -185,26 +252,30 @@ static inline const char *kernel_load_data_id_str(enum kernel_load_data_id id)
+ 
+ #ifdef CONFIG_SECURITY
+ 
+-struct security_mnt_opts {
++struct lsm_mnt_opts {
+ 	char **mnt_opts;
+ 	int *mnt_opts_flags;
+ 	int num_mnt_opts;
+ };
+ 
++struct security_mnt_opts {
++	struct lsm_mnt_opts     selinux;
++	struct lsm_mnt_opts     smack;
++};
++
+ int call_lsm_notifier(enum lsm_event event, void *data);
+ int register_lsm_notifier(struct notifier_block *nb);
+ int unregister_lsm_notifier(struct notifier_block *nb);
+ 
+ static inline void security_init_mnt_opts(struct security_mnt_opts *opts)
+ {
+-	opts->mnt_opts = NULL;
+-	opts->mnt_opts_flags = NULL;
+-	opts->num_mnt_opts = 0;
++	memset(opts, 0, sizeof(*opts));
+ }
+ 
+-static inline void security_free_mnt_opts(struct security_mnt_opts *opts)
++static inline void lsm_free_mnt_opts(struct lsm_mnt_opts *opts)
+ {
+ 	int i;
++
+ 	if (opts->mnt_opts)
+ 		for (i = 0; i < opts->num_mnt_opts; i++)
+ 			kfree(opts->mnt_opts[i]);
+@@ -215,6 +286,17 @@ static inline void security_free_mnt_opts(struct security_mnt_opts *opts)
+ 	opts->num_mnt_opts = 0;
+ }
+ 
++static inline void security_free_mnt_opts(struct security_mnt_opts *all_opts)
++{
++	lsm_free_mnt_opts(&all_opts->selinux);
++	lsm_free_mnt_opts(&all_opts->smack);
++}
++
++static inline int security_num_mnt_opts(struct security_mnt_opts *all_opts)
++{
++	return all_opts->selinux.num_mnt_opts + all_opts->smack.num_mnt_opts;
++}
++
+ /* prototypes */
+ extern int security_init(void);
+ 
+@@ -236,10 +318,10 @@ int security_capset(struct cred *new, const struct cred *old,
+ 		    const kernel_cap_t *effective,
+ 		    const kernel_cap_t *inheritable,
+ 		    const kernel_cap_t *permitted);
+-int security_capable(const struct cred *cred,
+-		       struct user_namespace *ns,
+-		       int cap,
+-		       unsigned int opts);
++int security_capable(const struct cred *cred, struct user_namespace *ns,
++			int cap);
++int security_capable_noaudit(const struct cred *cred, struct user_namespace *ns,
++			     int cap);
+ int security_quotactl(int cmds, int type, int id, struct super_block *sb);
+ int security_quota_on(struct dentry *dentry);
+ int security_syslog(int type);
+@@ -261,17 +343,18 @@ int security_sb_mount(const char *dev_name, const struct path *path,
+ int security_sb_umount(struct vfsmount *mnt, int flags);
+ int security_sb_pivotroot(const struct path *old_path, const struct path *new_path);
+ int security_sb_set_mnt_opts(struct super_block *sb,
+-				struct security_mnt_opts *opts,
++				struct security_mnt_opts *all_opts,
+ 				unsigned long kern_flags,
+ 				unsigned long *set_kern_flags);
+ int security_sb_clone_mnt_opts(const struct super_block *oldsb,
+ 				struct super_block *newsb,
+ 				unsigned long kern_flags,
+ 				unsigned long *set_kern_flags);
+-int security_sb_parse_opts_str(char *options, struct security_mnt_opts *opts);
++int security_sb_parse_opts_str(char *options,
++				struct security_mnt_opts *all_opts);
+ int security_dentry_init_security(struct dentry *dentry, int mode,
+-					const struct qstr *name, void **ctx,
+-					u32 *ctxlen);
++					const struct qstr *name,
++					struct lsm_context *cp);
+ int security_dentry_create_files_as(struct dentry *dentry, int mode,
+ 					struct qstr *name,
+ 					const struct cred *old,
+@@ -315,7 +398,7 @@ int security_inode_killpriv(struct dentry *dentry);
+ int security_inode_getsecurity(struct inode *inode, const char *name, void **buffer, bool alloc);
+ int security_inode_setsecurity(struct inode *inode, const char *name, const void *value, size_t size, int flags);
+ int security_inode_listsecurity(struct inode *inode, char *buffer, size_t buffer_size);
+-void security_inode_getsecid(struct inode *inode, u32 *secid);
++void security_inode_getsecid(struct inode *inode, struct lsm_export *l);
+ int security_inode_copy_up(struct dentry *src, struct cred **new);
+ int security_inode_copy_up_xattr(const char *name);
+ int security_file_permission(struct file *file, int mask);
+@@ -340,8 +423,8 @@ int security_cred_alloc_blank(struct cred *cred, gfp_t gfp);
+ void security_cred_free(struct cred *cred);
+ int security_prepare_creds(struct cred *new, const struct cred *old, gfp_t gfp);
+ void security_transfer_creds(struct cred *new, const struct cred *old);
+-void security_cred_getsecid(const struct cred *c, u32 *secid);
+-int security_kernel_act_as(struct cred *new, u32 secid);
++void security_cred_getsecid(const struct cred *c, struct lsm_export *l);
++int security_kernel_act_as(struct cred *new, struct lsm_export *l);
+ int security_kernel_create_files_as(struct cred *new, struct inode *inode);
+ int security_kernel_module_request(char *kmod_name);
+ int security_kernel_load_data(enum kernel_load_data_id id);
+@@ -353,7 +436,7 @@ int security_task_fix_setuid(struct cred *new, const struct cred *old,
+ int security_task_setpgid(struct task_struct *p, pid_t pgid);
+ int security_task_getpgid(struct task_struct *p);
+ int security_task_getsid(struct task_struct *p);
+-void security_task_getsecid(struct task_struct *p, u32 *secid);
++void security_task_getsecid(struct task_struct *p, struct lsm_export *l);
+ int security_task_setnice(struct task_struct *p, int nice);
+ int security_task_setioprio(struct task_struct *p, int ioprio);
+ int security_task_getioprio(struct task_struct *p);
+@@ -366,12 +449,11 @@ int security_task_getscheduler(struct task_struct *p);
+ int security_task_movememory(struct task_struct *p);
+ int security_task_kill(struct task_struct *p, struct siginfo *info,
+ 			int sig, const struct cred *cred);
+-void security_task_exit(struct task_struct *p);
+ int security_task_prctl(int option, unsigned long arg2, unsigned long arg3,
+ 			unsigned long arg4, unsigned long arg5);
+ void security_task_to_inode(struct task_struct *p, struct inode *inode);
+ int security_ipc_permission(struct kern_ipc_perm *ipcp, short flag);
+-void security_ipc_getsecid(struct kern_ipc_perm *ipcp, u32 *secid);
++void security_ipc_getsecid(struct kern_ipc_perm *ipcp, struct lsm_export *l);
+ int security_msg_msg_alloc(struct msg_msg *msg);
+ void security_msg_msg_free(struct msg_msg *msg);
+ int security_msg_queue_alloc(struct kern_ipc_perm *msq);
+@@ -394,18 +476,20 @@ int security_sem_semctl(struct kern_ipc_perm *sma, int cmd);
+ int security_sem_semop(struct kern_ipc_perm *sma, struct sembuf *sops,
+ 			unsigned nsops, int alter);
+ void security_d_instantiate(struct dentry *dentry, struct inode *inode);
+-int security_getprocattr(struct task_struct *p, char *name, char **value);
+-int security_setprocattr(const char *name, void *value, size_t size);
++int security_getprocattr(struct task_struct *p, const char *lsm, char *name,
++			 char **value);
++int security_setprocattr(const char *lsm, const char *name, void *value,
++			 size_t size);
+ int security_netlink_send(struct sock *sk, struct sk_buff *skb);
+ int security_ismaclabel(const char *name);
+-int security_secid_to_secctx(u32 secid, char **secdata, u32 *seclen);
+-int security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid);
+-void security_release_secctx(char *secdata, u32 seclen);
++int security_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp);
++int security_secctx_to_secid(struct lsm_context *cp, struct lsm_export *l);
++void security_release_secctx(struct lsm_context *cp);
+ 
+ void security_inode_invalidate_secctx(struct inode *inode);
+-int security_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen);
+-int security_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen);
+-int security_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen);
++int security_inode_notifysecctx(struct inode *inode, struct lsm_context *cp);
++int security_inode_setsecctx(struct dentry *dentry, struct lsm_context *cp);
++int security_inode_getsecctx(struct inode *inode, struct lsm_context *cp);
+ #else /* CONFIG_SECURITY */
+ struct security_mnt_opts {
+ };
+@@ -425,11 +509,11 @@ static inline  int unregister_lsm_notifier(struct notifier_block *nb)
+ 	return 0;
+ }
+ 
+-static inline void security_init_mnt_opts(struct security_mnt_opts *opts)
++static inline void security_init_mnt_opts(struct security_mnt_opts *all_opts)
+ {
+ }
+ 
+-static inline void security_free_mnt_opts(struct security_mnt_opts *opts)
++static inline void security_free_mnt_opts(struct security_mnt_opts *all_opts)
+ {
+ }
+ 
+@@ -496,11 +580,14 @@ static inline int security_capset(struct cred *new,
+ }
+ 
+ static inline int security_capable(const struct cred *cred,
+-				   struct user_namespace *ns,
+-				   int cap,
+-				   unsigned int opts)
++				   struct user_namespace *ns, int cap)
+ {
+-	return cap_capable(cred, ns, cap, opts);
++	return cap_capable(cred, ns, cap, SECURITY_CAP_AUDIT);
++}
++
++static inline int security_capable_noaudit(const struct cred *cred,
++					   struct user_namespace *ns, int cap) {
++	return cap_capable(cred, ns, cap, SECURITY_CAP_NOAUDIT);
+ }
+ 
+ static inline int security_quotactl(int cmds, int type, int id,
+@@ -601,7 +688,7 @@ static inline int security_sb_pivotroot(const struct path *old_path,
+ }
+ 
+ static inline int security_sb_set_mnt_opts(struct super_block *sb,
+-					   struct security_mnt_opts *opts,
++					   struct security_mnt_opts *all_opts,
+ 					   unsigned long kern_flags,
+ 					   unsigned long *set_kern_flags)
+ {
+@@ -616,7 +703,8 @@ static inline int security_sb_clone_mnt_opts(const struct super_block *oldsb,
+ 	return 0;
+ }
+ 
+-static inline int security_sb_parse_opts_str(char *options, struct security_mnt_opts *opts)
++static inline int security_sb_parse_opts_str(char *options,
++					struct security_mnt_opts *all_opts)
+ {
+ 	return 0;
+ }
+@@ -632,8 +720,7 @@ static inline void security_inode_free(struct inode *inode)
+ static inline int security_dentry_init_security(struct dentry *dentry,
+ 						 int mode,
+ 						 const struct qstr *name,
+-						 void **ctx,
+-						 u32 *ctxlen)
++						 struct lsm_context *cp)
+ {
+ 	return -EOPNOTSUPP;
+ }
+@@ -801,9 +888,10 @@ static inline int security_inode_listsecurity(struct inode *inode, char *buffer,
+ 	return 0;
+ }
+ 
+-static inline void security_inode_getsecid(struct inode *inode, u32 *secid)
++static inline void security_inode_getsecid(struct inode *inode,
++					   struct lsm_export *l)
+ {
+-	*secid = 0;
++	lsm_export_init(l);
+ }
+ 
+ static inline int security_inode_copy_up(struct dentry *src, struct cred **new)
+@@ -915,7 +1003,8 @@ static inline void security_transfer_creds(struct cred *new,
+ {
+ }
+ 
+-static inline int security_kernel_act_as(struct cred *cred, u32 secid)
++static inline int security_kernel_act_as(struct cred *cred,
++					 struct lsm_export *l)
+ {
+ 	return 0;
+ }
+@@ -971,9 +1060,10 @@ static inline int security_task_getsid(struct task_struct *p)
+ 	return 0;
+ }
+ 
+-static inline void security_task_getsecid(struct task_struct *p, u32 *secid)
++static inline void security_task_getsecid(struct task_struct *p,
++					  struct lsm_export *l)
+ {
+-	*secid = 0;
++	lsm_export_init(l);
+ }
+ 
+ static inline int security_task_setnice(struct task_struct *p, int nice)
+@@ -1027,9 +1117,6 @@ static inline int security_task_kill(struct task_struct *p,
+ 	return 0;
+ }
+ 
+-static inline void security_task_exit(struct task_struct *p)
+-{ }
+-
+ static inline int security_task_prctl(int option, unsigned long arg2,
+ 				      unsigned long arg3,
+ 				      unsigned long arg4,
+@@ -1047,9 +1134,10 @@ static inline int security_ipc_permission(struct kern_ipc_perm *ipcp,
+ 	return 0;
+ }
+ 
+-static inline void security_ipc_getsecid(struct kern_ipc_perm *ipcp, u32 *secid)
++static inline void security_ipc_getsecid(struct kern_ipc_perm *ipcp,
++					 struct lsm_export *l)
+ {
+-	*secid = 0;
++	lsm_export_init(l);
+ }
+ 
+ static inline int security_msg_msg_alloc(struct msg_msg *msg)
+@@ -1143,15 +1231,18 @@ static inline int security_sem_semop(struct kern_ipc_perm *sma,
+ 	return 0;
+ }
+ 
+-static inline void security_d_instantiate(struct dentry *dentry, struct inode *inode)
++static inline void security_d_instantiate(struct dentry *dentry,
++					  struct inode *inode)
+ { }
+ 
+-static inline int security_getprocattr(struct task_struct *p, char *name, char **value)
++static inline int security_getprocattr(struct task_struct *p, const char *lsm,
++				       char *name, char **value)
+ {
+ 	return -EINVAL;
+ }
+ 
+-static inline int security_setprocattr(char *name, void *value, size_t size)
++static inline int security_setprocattr(const char *lsm, char *name,
++				       void *value, size_t size)
+ {
+ 	return -EINVAL;
+ }
+@@ -1166,19 +1257,19 @@ static inline int security_ismaclabel(const char *name)
+ 	return 0;
+ }
+ 
+-static inline int security_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
++static inline int security_secid_to_secctx(struct lsm_export *l,
++					   struct lsm_seccontext *cp)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static inline int security_secctx_to_secid(const char *secdata,
+-					   u32 seclen,
+-					   u32 *secid)
++static inline int security_secctx_to_secid(struct lsm_context *cp,
++					   struct lsm_export *l)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static inline void security_release_secctx(char *secdata, u32 seclen)
++static inline void security_release_secctx(struct lsm_context *cp);
+ {
+ }
+ 
+@@ -1186,15 +1277,18 @@ static inline void security_inode_invalidate_secctx(struct inode *inode)
+ {
+ }
+ 
+-static inline int security_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen)
++static inline int security_inode_notifysecctx(struct inode *inode,
++					      struct lsm_context *cp);
+ {
+ 	return -EOPNOTSUPP;
+ }
+-static inline int security_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen)
++static inline int security_inode_setsecctx(struct dentry *dentry,
++					   struct lsm_context *cp)
+ {
+ 	return -EOPNOTSUPP;
+ }
+-static inline int security_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen)
++static inline int security_inode_getsecctx(struct inode *inode,
++					   struct lsm_context *cp);
+ {
+ 	return -EOPNOTSUPP;
+ }
+@@ -1223,7 +1317,8 @@ int security_socket_shutdown(struct socket *sock, int how);
+ int security_sock_rcv_skb(struct sock *sk, struct sk_buff *skb);
+ int security_socket_getpeersec_stream(struct socket *sock, char __user *optval,
+ 				      int __user *optlen, unsigned len);
+-int security_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb, u32 *secid);
++int security_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb,
++				     struct lsm_export *l);
+ int security_sk_alloc(struct sock *sk, int family, gfp_t priority);
+ void security_sk_free(struct sock *sk);
+ void security_sk_clone(const struct sock *sk, struct sock *newsk);
+@@ -1361,7 +1456,9 @@ static inline int security_socket_getpeersec_stream(struct socket *sock, char __
+ 	return -ENOPROTOOPT;
+ }
+ 
+-static inline int security_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb, u32 *secid)
++static inline int security_socket_getpeersec_dgram(struct socket *sock,
++						   struct sk_buff *skb,
++						   struct lsm_export *l)
+ {
+ 	return -ENOPROTOOPT;
+ }
+@@ -1705,8 +1802,8 @@ static inline int security_key_getsecurity(struct key *key, char **_buffer)
+ #ifdef CONFIG_SECURITY
+ int security_audit_rule_init(u32 field, u32 op, char *rulestr, void **lsmrule);
+ int security_audit_rule_known(struct audit_krule *krule);
+-int security_audit_rule_match(u32 secid, u32 field, u32 op, void *lsmrule,
+-			      struct audit_context *actx);
++int security_audit_rule_match(struct lsm_export *l, u32 field, u32 op,
++			      void *lsmrule, struct audit_context *actx);
+ void security_audit_rule_free(void *lsmrule);
+ 
+ #else
+@@ -1722,8 +1819,9 @@ static inline int security_audit_rule_known(struct audit_krule *krule)
+ 	return 0;
+ }
+ 
+-static inline int security_audit_rule_match(u32 secid, u32 field, u32 op,
+-				   void *lsmrule, struct audit_context *actx)
++static inline int security_audit_rule_match(struct lsm_export *l, u32 field,
++						u32 op, void *lsmrule,
++						struct audit_context *actx)
+ {
+ 	return 0;
+ }
+diff --git a/include/net/netlabel.h b/include/net/netlabel.h
+index 72d6435fc16c..546c75f27d05 100644
+--- a/include/net/netlabel.h
++++ b/include/net/netlabel.h
+@@ -111,7 +111,7 @@ struct calipso_doi;
+ 
+ /* NetLabel audit information */
+ struct netlbl_audit {
+-	u32 secid;
++	struct lsm_export le;
+ 	kuid_t loginuid;
+ 	unsigned int sessionid;
+ };
+@@ -180,7 +180,7 @@ struct netlbl_lsm_catmap {
+  * @attr.mls: MLS sensitivity label
+  * @attr.mls.cat: MLS category bitmap
+  * @attr.mls.lvl: MLS sensitivity level
+- * @attr.secid: LSM specific secid token
++ * @attr.le: LSM specific data
+  *
+  * Description:
+  * This structure is used to pass security attributes between NetLabel and the
+@@ -215,7 +215,7 @@ struct netlbl_lsm_secattr {
+ 			struct netlbl_lsm_catmap *cat;
+ 			u32 lvl;
+ 		} mls;
+-		u32 secid;
++		struct lsm_export le;
+ 	} attr;
+ };
+ 
+@@ -429,7 +429,7 @@ int netlbl_cfg_unlbl_static_add(struct net *net,
+ 				const void *addr,
+ 				const void *mask,
+ 				u16 family,
+-				u32 secid,
++				struct lsm_export *l,
+ 				struct netlbl_audit *audit_info);
+ int netlbl_cfg_unlbl_static_del(struct net *net,
+ 				const char *dev_name,
+@@ -537,7 +537,7 @@ static inline int netlbl_cfg_unlbl_static_add(struct net *net,
+ 					      const void *addr,
+ 					      const void *mask,
+ 					      u16 family,
+-					      u32 secid,
++					      struct lsm_export *l,
+ 					      struct netlbl_audit *audit_info)
+ {
+ 	return -ENOSYS;
+diff --git a/include/net/scm.h b/include/net/scm.h
+index 1ce365f4c256..b25ca3b6a514 100644
+--- a/include/net/scm.h
++++ b/include/net/scm.h
+@@ -33,7 +33,7 @@ struct scm_cookie {
+ 	struct scm_fp_list	*fp;		/* Passed files		*/
+ 	struct scm_creds	creds;		/* Skb credentials	*/
+ #ifdef CONFIG_SECURITY_NETWORK
+-	u32			secid;		/* Passed security ID 	*/
++	struct lsm_export	le;		/* Passed LSM data */
+ #endif
+ };
+ 
+@@ -46,7 +46,7 @@ struct scm_fp_list *scm_fp_dup(struct scm_fp_list *fpl);
+ #ifdef CONFIG_SECURITY_NETWORK
+ static __inline__ void unix_get_peersec_dgram(struct socket *sock, struct scm_cookie *scm)
+ {
+-	security_socket_getpeersec_dgram(sock, NULL, &scm->secid);
++	security_socket_getpeersec_dgram(sock, NULL, &scm->le);
+ }
+ #else
+ static __inline__ void unix_get_peersec_dgram(struct socket *sock, struct scm_cookie *scm)
+@@ -92,16 +92,16 @@ static __inline__ int scm_send(struct socket *sock, struct msghdr *msg,
+ #ifdef CONFIG_SECURITY_NETWORK
+ static inline void scm_passec(struct socket *sock, struct msghdr *msg, struct scm_cookie *scm)
+ {
+-	char *secdata;
+-	u32 seclen;
++	struct lsm_context lc;
+ 	int err;
+ 
+ 	if (test_bit(SOCK_PASSSEC, &sock->flags)) {
+-		err = security_secid_to_secctx(scm->secid, &secdata, &seclen);
++		err = security_secid_to_secctx(&scm->le, &lc);
+ 
+ 		if (!err) {
+-			put_cmsg(msg, SOL_SOCKET, SCM_SECURITY, seclen, secdata);
+-			security_release_secctx(secdata, seclen);
++			put_cmsg(msg, SOL_SOCKET, SCM_SECURITY,
++				 lc.len, lc.context);
++			security_release_secctx(&lc);
+ 		}
+ 	}
+ }
+diff --git a/kernel/audit.c b/kernel/audit.c
+index 55a1b8f30b79..8747f992f80f 100644
+--- a/kernel/audit.c
++++ b/kernel/audit.c
+@@ -136,9 +136,9 @@ static u32	audit_backlog_limit = 64;
+ static u32	audit_backlog_wait_time = AUDIT_BACKLOG_WAIT_TIME;
+ 
+ /* The identity of the user shutting down the audit system. */
+-kuid_t		audit_sig_uid = INVALID_UID;
+-pid_t		audit_sig_pid = -1;
+-u32		audit_sig_sid = 0;
++kuid_t      audit_sig_uid = INVALID_UID;
++pid_t       audit_sig_pid = -1;
++struct lsm_export      audit_sig_lsm;
+ 
+ /* Records can be lost in several ways:
+    0) [suppressed in audit_alloc]
+@@ -1253,8 +1253,7 @@ static int audit_receive_msg(struct sk_buff *skb, struct nlmsghdr *nlh)
+ 	struct audit_buffer	*ab;
+ 	u16			msg_type = nlh->nlmsg_type;
+ 	struct audit_sig_info   *sig_data;
+-	char			*ctx = NULL;
+-	u32			len;
++    struct lsm_context      lc = { .context = NULL, .len = 0, };
+ 
+ 	err = audit_netlink_ok(skb, msg_type);
+ 	if (err)
+@@ -1485,26 +1484,25 @@ static int audit_receive_msg(struct sk_buff *skb, struct nlmsghdr *nlh)
+ 		break;
+ 	}
+ 	case AUDIT_SIGNAL_INFO:
+-		len = 0;
+-		if (audit_sig_sid) {
+-			err = security_secid_to_secctx(audit_sig_sid, &ctx, &len);
++        if (lsm_export_any(&audit_sig_lsm)) {
++            err = security_secid_to_secctx(&audit_sig_lsm, &lc);
+ 			if (err)
+ 				return err;
+ 		}
+-		sig_data = kmalloc(sizeof(*sig_data) + len, GFP_KERNEL);
++        sig_data = kmalloc(sizeof(*sig_data) + lc.len, GFP_KERNEL);
+ 		if (!sig_data) {
+-			if (audit_sig_sid)
+-				security_release_secctx(ctx, len);
++            if (lsm_export_any(&audit_sig_lsm))
++                security_release_secctx(&lc);
+ 			return -ENOMEM;
+ 		}
+ 		sig_data->uid = from_kuid(&init_user_ns, audit_sig_uid);
+ 		sig_data->pid = audit_sig_pid;
+-		if (audit_sig_sid) {
+-			memcpy(sig_data->ctx, ctx, len);
+-			security_release_secctx(ctx, len);
++        if (lsm_export_any(&audit_sig_lsm)) {
++            memcpy(sig_data->ctx, lc.context, lc.len);
++            security_release_secctx(&lc);
+ 		}
+ 		audit_send_reply(skb, seq, AUDIT_SIGNAL_INFO, 0, 0,
+-				 sig_data, sizeof(*sig_data) + len);
++				 sig_data, sizeof(*sig_data) + lc.len);
+ 		kfree(sig_data);
+ 		break;
+ 	case AUDIT_TTY_GET: {
+@@ -2180,7 +2178,7 @@ void audit_copy_inode(struct audit_names *name, const struct dentry *dentry,
+ 	name->uid   = inode->i_uid;
+ 	name->gid   = inode->i_gid;
+ 	name->rdev  = inode->i_rdev;
+-	security_inode_getsecid(inode, &name->osid);
++    security_inode_getsecid(inode, &name->olsm);
+ 	audit_copy_fcaps(name, dentry);
+ }
+ 
+@@ -2237,17 +2235,16 @@ void audit_log_name(struct audit_context *context, struct audit_names *n,
+ 				 from_kgid(&init_user_ns, n->gid),
+ 				 MAJOR(n->rdev),
+ 				 MINOR(n->rdev));
+-	if (n->osid != 0) {
+-		char *ctx = NULL;
+-		u32 len;
+-		if (security_secid_to_secctx(
+-			n->osid, &ctx, &len)) {
+-			audit_log_format(ab, " osid=%u", n->osid);
++    if (lsm_export_any(&n->olsm)) {
++        struct lsm_context lc;
++
++        if (security_secid_to_secctx(&n->olsm, &lc)) {
++            audit_log_format(ab, " osid=(unknown)");
+ 			if (call_panic)
+ 				*call_panic = 2;
+ 		} else {
+-			audit_log_format(ab, " obj=%s", ctx);
+-			security_release_secctx(ctx, len);
++            audit_log_format(ab, " obj=%s", lc.context);
++            security_release_secctx(&lc);
+ 		}
+ 	}
+ 
+@@ -2277,24 +2274,23 @@ void audit_log_name(struct audit_context *context, struct audit_names *n,
+ 
+ int audit_log_task_context(struct audit_buffer *ab)
+ {
+-	char *ctx = NULL;
+-	unsigned len;
+ 	int error;
+-	u32 sid;
++    struct lsm_export le;
++    struct lsm_context lc = { .context = NULL, };
+ 
+-	security_task_getsecid(current, &sid);
+-	if (!sid)
++    security_task_getsecid(current, &le);
++    if (!lsm_export_any(&le))
+ 		return 0;
+ 
+-	error = security_secid_to_secctx(sid, &ctx, &len);
++    error = security_secid_to_secctx(&le, &lc);
+ 	if (error) {
+ 		if (error != -EINVAL)
+ 			goto error_path;
+ 		return 0;
+ 	}
+ 
+-	audit_log_format(ab, " subj=%s", ctx);
+-	security_release_secctx(ctx, len);
++    audit_log_format(ab, " subj=%s", lc.context);
++    security_release_secctx(&lc);
+ 	return 0;
+ 
+ error_path:
+diff --git a/kernel/audit.h b/kernel/audit.h
+index 6bf56f357331..cf2b2d6e7e9b 100644
+--- a/kernel/audit.h
++++ b/kernel/audit.h
+@@ -24,6 +24,7 @@
+ #include <linux/skbuff.h>
+ #include <uapi/linux/mqueue.h>
+ #include <linux/tty.h>
++#include <linux/security.h>
+ 
+ /* AUDIT_NAMES is the number of slots we reserve in the audit_context
+  * for saving names from getname().  If we get more names we will allocate
+@@ -89,7 +90,7 @@ struct audit_names {
+ 	kuid_t			uid;
+ 	kgid_t			gid;
+ 	dev_t			rdev;
+-	u32			osid;
++    struct lsm_export       olsm;
+ 	struct audit_cap_data	fcap;
+ 	unsigned int		fcap_ver;
+ 	unsigned char		type;		/* record type */
+@@ -146,7 +147,7 @@ struct audit_context {
+ 	kuid_t		    target_auid;
+ 	kuid_t		    target_uid;
+ 	unsigned int	    target_sessionid;
+-	u32		    target_sid;
++    struct lsm_export   target_lsm;
+ 	u64		    target_cid;
+ 	char		    target_comm[TASK_COMM_LEN];
+ 
+@@ -164,7 +165,7 @@ struct audit_context {
+ 			kuid_t			uid;
+ 			kgid_t			gid;
+ 			umode_t			mode;
+-			u32			osid;
++            struct lsm_export       olsm;
+ 			int			has_perm;
+ 			uid_t			perm_uid;
+ 			gid_t			perm_gid;
+@@ -334,6 +335,7 @@ extern char *audit_unpack_string(void **bufp, size_t *remain, size_t len);
+ extern pid_t audit_sig_pid;
+ extern kuid_t audit_sig_uid;
+ extern u32 audit_sig_sid;
++extern struct lsm_export audit_sig_lsm;
+ 
+ extern int audit_filter(int msgtype, unsigned int listtype);
+ 
+diff --git a/kernel/auditfilter.c b/kernel/auditfilter.c
+index 425c67e4f568..2bf8c2a82b04 100644
+--- a/kernel/auditfilter.c
++++ b/kernel/auditfilter.c
+@@ -1325,7 +1325,7 @@ int audit_filter(int msgtype, unsigned int listtype)
+ 		for (i = 0; i < e->rule.field_count; i++) {
+ 			struct audit_field *f = &e->rule.fields[i];
+ 			pid_t pid;
+-			u32 sid;
++            struct lsm_export le;
+ 
+ 			switch (f->type) {
+ 			case AUDIT_PID:
+@@ -1355,8 +1355,8 @@ int audit_filter(int msgtype, unsigned int listtype)
+ 			case AUDIT_SUBJ_SEN:
+ 			case AUDIT_SUBJ_CLR:
+ 				if (f->lsm_rule) {
+-					security_task_getsecid(current, &sid);
+-					result = security_audit_rule_match(sid,
++                    security_task_getsecid(current, &le);
++                    result = security_audit_rule_match(&le,
+ 							f->type, f->op, f->lsm_rule, NULL);
+ 				}
+ 				break;
+diff --git a/kernel/auditsc.c b/kernel/auditsc.c
+index 9c32b70698f5..3d7451ce65ed 100644
+--- a/kernel/auditsc.c
++++ b/kernel/auditsc.c
+@@ -112,7 +112,7 @@ struct audit_aux_data_pids {
+ 	kuid_t			target_auid[AUDIT_AUX_PIDS];
+ 	kuid_t			target_uid[AUDIT_AUX_PIDS];
+ 	unsigned int		target_sessionid[AUDIT_AUX_PIDS];
+-	u32			target_sid[AUDIT_AUX_PIDS];
++    struct lsm_export       target_lsm[AUDIT_AUX_PIDS];
+ 	u64			target_cid[AUDIT_AUX_PIDS];
+ 	char 			target_comm[AUDIT_AUX_PIDS][TASK_COMM_LEN];
+ 	int			pid_count;
+@@ -451,7 +451,7 @@ static int audit_filter_rules(struct task_struct *tsk,
+ {
+ 	const struct cred *cred;
+ 	int i, need_sid = 1;
+-	u32 sid;
++    struct lsm_export le;
+ 	unsigned int sessionid;
+ 
+ 	cred = rcu_dereference_check(tsk->cred, tsk == current || task_creation);
+@@ -634,10 +634,10 @@ static int audit_filter_rules(struct task_struct *tsk,
+ 			   logged upon error */
+ 			if (f->lsm_rule) {
+ 				if (need_sid) {
+-					security_task_getsecid(tsk, &sid);
++					security_task_getsecid(tsk, &le);
+ 					need_sid = 0;
+ 				}
+-				result = security_audit_rule_match(sid, f->type,
++                result = security_audit_rule_match(&le, f->type,
+ 				                                  f->op,
+ 				                                  f->lsm_rule,
+ 				                                  ctx);
+@@ -654,11 +654,11 @@ static int audit_filter_rules(struct task_struct *tsk,
+ 				/* Find files that match */
+ 				if (name) {
+ 					result = security_audit_rule_match(
+-					           name->osid, f->type, f->op,
++                               &name->olsm, f->type, f->op,
+ 					           f->lsm_rule, ctx);
+ 				} else if (ctx) {
+ 					list_for_each_entry(n, &ctx->names_list, list) {
+-						if (security_audit_rule_match(n->osid, f->type,
++                        if (security_audit_rule_match(&n->olsm, f->type,
+ 									      f->op, f->lsm_rule,
+ 									      ctx)) {
+ 							++result;
+@@ -669,7 +669,7 @@ static int audit_filter_rules(struct task_struct *tsk,
+ 				/* Find ipc objects that match */
+ 				if (!ctx || ctx->type != AUDIT_IPC)
+ 					break;
+-				if (security_audit_rule_match(ctx->ipc.osid,
++                if (security_audit_rule_match(&ctx->ipc.olsm,
+ 							      f->type, f->op,
+ 							      f->lsm_rule, ctx))
+ 					++result;
+@@ -978,12 +978,12 @@ static inline void audit_free_context(struct audit_context *context)
+ }
+ 
+ static int audit_log_pid_context(struct audit_context *context, pid_t pid,
+-				 kuid_t auid, kuid_t uid, unsigned int sessionid,
+-				 u32 sid, char *comm)
++                 kuid_t auid, kuid_t uid,
++                 unsigned int sessionid,
++                 struct lsm_export *l, char *comm)
+ {
++    struct lsm_context lc;
+ 	struct audit_buffer *ab;
+-	char *ctx = NULL;
+-	u32 len;
+ 	int rc = 0;
+ 
+ 	ab = audit_log_start(context, GFP_KERNEL, AUDIT_OBJ_PID);
+@@ -993,13 +993,13 @@ static int audit_log_pid_context(struct audit_context *context, pid_t pid,
+ 	audit_log_format(ab, "opid=%d oauid=%d ouid=%d oses=%d", pid,
+ 			 from_kuid(&init_user_ns, auid),
+ 			 from_kuid(&init_user_ns, uid), sessionid);
+-	if (sid) {
+-		if (security_secid_to_secctx(sid, &ctx, &len)) {
++    if (lsm_export_any(l)) {
++        if (security_secid_to_secctx(l, &lc)) {
+ 			audit_log_format(ab, " obj=(none)");
+ 			rc = 1;
+ 		} else {
+-			audit_log_format(ab, " obj=%s", ctx);
+-			security_release_secctx(ctx, len);
++            audit_log_format(ab, " obj=%s", lc.context);
++            security_release_secctx(&lc);
+ 		}
+ 	}
+ 	audit_log_format(ab, " ocomm=");
+@@ -1201,21 +1201,20 @@ static void show_special(struct audit_context *context, int *call_panic)
+ 				context->socketcall.args[i]);
+ 		break; }
+ 	case AUDIT_IPC: {
+-		u32 osid = context->ipc.osid;
++        struct lsm_export *l = &context->ipc.olsm;
+ 
+ 		audit_log_format(ab, "ouid=%u ogid=%u mode=%#ho",
+ 				 from_kuid(&init_user_ns, context->ipc.uid),
+ 				 from_kgid(&init_user_ns, context->ipc.gid),
+ 				 context->ipc.mode);
+-		if (osid) {
+-			char *ctx = NULL;
+-			u32 len;
+-			if (security_secid_to_secctx(osid, &ctx, &len)) {
+-				audit_log_format(ab, " osid=%u", osid);
++		if (lsm_export_any(l)) {
++            struct lsm_context lc;
++            if (security_secid_to_secctx(l, &lc)) {
++                audit_log_format(ab, " osid=(unknown)");
+ 				*call_panic = 1;
+ 			} else {
+-				audit_log_format(ab, " obj=%s", ctx);
+-				security_release_secctx(ctx, len);
++                audit_log_format(ab, " obj=%s", lc.context);
++                security_release_secctx(&lc);
+ 			}
+ 		}
+ 		if (context->ipc.has_perm) {
+@@ -1438,7 +1437,7 @@ static void audit_log_exit(struct audit_context *context, struct task_struct *ts
+ 						  axs->target_auid[i],
+ 						  axs->target_uid[i],
+ 						  axs->target_sessionid[i],
+-						  axs->target_sid[i],
++                          &axs->target_lsm[i],
+ 						  axs->target_comm[i]))
+ 				call_panic = 1;
+ 	}
+@@ -1447,7 +1446,7 @@ static void audit_log_exit(struct audit_context *context, struct task_struct *ts
+ 	    audit_log_pid_context(context, context->target_pid,
+ 				  context->target_auid, context->target_uid,
+ 				  context->target_sessionid,
+-				  context->target_sid, context->target_comm))
++                  &context->target_lsm, context->target_comm))
+ 			call_panic = 1;
+ 
+ 	if (context->pwd.dentry && context->pwd.mnt) {
+@@ -1592,7 +1591,7 @@ void __audit_syscall_exit(int success, long return_code)
+ 	context->aux = NULL;
+ 	context->aux_pids = NULL;
+ 	context->target_pid = 0;
+-	context->target_sid = 0;
++    lsm_export_init(&context->target_lsm);
+ 	context->sockaddr_len = 0;
+ 	context->type = 0;
+ 	context->fds[0] = -1;
+@@ -2179,7 +2178,7 @@ void __audit_ipc_obj(struct kern_ipc_perm *ipcp)
+ 	context->ipc.gid = ipcp->gid;
+ 	context->ipc.mode = ipcp->mode;
+ 	context->ipc.has_perm = 0;
+-	security_ipc_getsecid(ipcp, &context->ipc.osid);
++    security_ipc_getsecid(ipcp, &context->ipc.olsm);
+ 	context->type = AUDIT_IPC;
+ }
+ 
+@@ -2274,8 +2273,8 @@ void __audit_ptrace(struct task_struct *t)
+ 	context->target_auid = audit_get_loginuid(t);
+ 	context->target_uid = task_uid(t);
+ 	context->target_sessionid = audit_get_sessionid(t);
+-	security_task_getsecid(t, &context->target_sid);
+ 	context->target_cid = audit_get_contid(t);
++    security_task_getsecid(t, &context->target_lsm);
+ 	memcpy(context->target_comm, t->comm, TASK_COMM_LEN);
+ }
+ 
+@@ -2302,7 +2301,7 @@ int audit_signal_info(int sig, struct task_struct *t)
+ 			audit_sig_uid = auid;
+ 		else
+ 			audit_sig_uid = uid;
+-		security_task_getsecid(current, &audit_sig_sid);
++        security_task_getsecid(current, &audit_sig_lsm);
+ 	}
+ 
+ 	if (!audit_signals || audit_dummy_context())
+@@ -2315,7 +2314,7 @@ int audit_signal_info(int sig, struct task_struct *t)
+ 		ctx->target_auid = audit_get_loginuid(t);
+ 		ctx->target_uid = t_uid;
+ 		ctx->target_sessionid = audit_get_sessionid(t);
+-		security_task_getsecid(t, &ctx->target_sid);
++        security_task_getsecid(t, &ctx->target_lsm);
+ 		ctx->target_cid = audit_get_contid(t);
+ 		memcpy(ctx->target_comm, t->comm, TASK_COMM_LEN);
+ 		return 0;
+@@ -2337,7 +2336,7 @@ int audit_signal_info(int sig, struct task_struct *t)
+ 	axp->target_auid[axp->pid_count] = audit_get_loginuid(t);
+ 	axp->target_uid[axp->pid_count] = t_uid;
+ 	axp->target_sessionid[axp->pid_count] = audit_get_sessionid(t);
+-	security_task_getsecid(t, &axp->target_sid[axp->pid_count]);
++    security_task_getsecid(t, &axp->target_lsm[axp->pid_count]);
+ 	axp->target_cid[axp->pid_count] = audit_get_contid(t);
+ 	memcpy(axp->target_comm[axp->pid_count], t->comm, TASK_COMM_LEN);
+ 	axp->pid_count++;
+diff --git a/kernel/capability.c b/kernel/capability.c
+index e0734ace5bc2..3381fc8ea1b8 100644
+--- a/kernel/capability.c
++++ b/kernel/capability.c
+@@ -299,7 +299,7 @@ bool has_ns_capability(struct task_struct *t,
+ 	int ret;
+ 
+ 	rcu_read_lock();
+-	ret = security_capable(__task_cred(t), ns, cap, CAP_OPT_NONE);
++    security_capable(__task_cred(t), ns, cap);
+ 	rcu_read_unlock();
+ 
+ 	return (ret == 0);
+@@ -340,7 +340,7 @@ bool has_ns_capability_noaudit(struct task_struct *t,
+ 	int ret;
+ 
+ 	rcu_read_lock();
+-	ret = security_capable(__task_cred(t), ns, cap, CAP_OPT_NOAUDIT);
++	ret = security_capable(__task_cred(t), ns, cap);
+ 	rcu_read_unlock();
+ 
+ 	return (ret == 0);
+@@ -363,23 +363,22 @@ bool has_capability_noaudit(struct task_struct *t, int cap)
+ 	return has_ns_capability_noaudit(t, &init_user_ns, cap);
+ }
+ 
+-static bool ns_capable_common(struct user_namespace *ns,
+-			      int cap,
+-			      unsigned int opts)
++static bool ns_capable_common(struct user_namespace *ns, int cap, bool audit)
+ {
+-	int capable;
+-
+-	if (unlikely(!cap_valid(cap))) {
+-		pr_crit("capable() called with invalid cap=%u\n", cap);
+-		BUG();
+-	}
+-
+-	capable = security_capable(current_cred(), ns, cap, opts);
+-	if (capable == 0) {
+-		current->flags |= PF_SUPERPRIV;
+-		return true;
+-	}
+-	return false;
++    int capable;
++
++    if (unlikely(!cap_valid(cap))) {
++        pr_crit("capable() called with invalid cap=%u\n", cap);
++        BUG();
++    }
++
++    capable = audit ? security_capable(current_cred(), ns, cap) :
++              security_capable_noaudit(current_cred(), ns, cap);
++    if (capable == 0) {
++        current->flags |= PF_SUPERPRIV;
++        return true;
++    }
++    return false;
+ }
+ 
+ /**
+@@ -395,7 +394,7 @@ static bool ns_capable_common(struct user_namespace *ns,
+  */
+ bool ns_capable(struct user_namespace *ns, int cap)
+ {
+-	return ns_capable_common(ns, cap, CAP_OPT_NONE);
++	return ns_capable_common(ns, cap, true);
+ }
+ EXPORT_SYMBOL(ns_capable);
+ 
+@@ -413,7 +412,7 @@ EXPORT_SYMBOL(ns_capable);
+  */
+ bool ns_capable_noaudit(struct user_namespace *ns, int cap)
+ {
+-	return ns_capable_common(ns, cap, CAP_OPT_NOAUDIT);
++	return ns_capable_common(ns, cap, false);
+ }
+ EXPORT_SYMBOL(ns_capable_noaudit);
+ 
+@@ -432,7 +431,7 @@ EXPORT_SYMBOL(ns_capable_noaudit);
+  */
+ bool ns_capable_setid(struct user_namespace *ns, int cap)
+ {
+-	return ns_capable_common(ns, cap, CAP_OPT_INSETID);
++	return ns_capable_common(ns, cap, true);
+ }
+ EXPORT_SYMBOL(ns_capable_setid);
+ 
+@@ -472,7 +471,7 @@ bool file_ns_capable(const struct file *file, struct user_namespace *ns,
+ 	if (WARN_ON_ONCE(!cap_valid(cap)))
+ 		return false;
+ 
+-	if (security_capable(file->f_cred, ns, cap, CAP_OPT_NONE) == 0)
++	if (security_capable(file->f_cred, ns, cap) == 0)
+ 		return true;
+ 
+ 	return false;
+@@ -525,8 +524,7 @@ bool ptracer_capable(struct task_struct *tsk, struct user_namespace *ns)
+ 	rcu_read_lock();
+ 	cred = rcu_dereference(tsk->ptracer_cred);
+ 	if (cred)
+-		ret = security_capable(cred, ns, CAP_SYS_PTRACE,
+-				       CAP_OPT_NOAUDIT);
++		ret = security_capable(cred, ns, CAP_SYS_PTRACE);
+ 	rcu_read_unlock();
+ 	return (ret == 0);
+ }
+diff --git a/kernel/cred.c b/kernel/cred.c
+index a9f0f8b21d8c..c21efa891124 100644
+--- a/kernel/cred.c
++++ b/kernel/cred.c
+@@ -676,9 +676,9 @@ EXPORT_SYMBOL(prepare_kernel_cred);
+  * Set the LSM security ID in a set of credentials so that the subjective
+  * security is overridden when an alternative set of credentials is used.
+  */
+-int set_security_override(struct cred *new, u32 secid)
++int set_security_override(struct cred *new, struct lsm_export *l)
+ {
+-	return security_kernel_act_as(new, secid);
++    return security_kernel_act_as(new, l);
+ }
+ EXPORT_SYMBOL(set_security_override);
+ 
+@@ -694,14 +694,17 @@ EXPORT_SYMBOL(set_security_override);
+  */
+ int set_security_override_from_ctx(struct cred *new, const char *secctx)
+ {
+-	u32 secid;
++    struct lsm_context lc;
++    struct lsm_export le;
+ 	int ret;
+ 
+-	ret = security_secctx_to_secid(secctx, strlen(secctx), &secid);
++    lc.context = secctx;
++    lc.len = strlen(secctx);
++    ret = security_secctx_to_secid(&lc, &le);
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return set_security_override(new, secid);
++    return set_security_override(new, &le);
+ }
+ EXPORT_SYMBOL(set_security_override_from_ctx);
+ 
+@@ -730,19 +733,6 @@ bool creds_are_invalid(const struct cred *cred)
+ {
+ 	if (cred->magic != CRED_MAGIC)
+ 		return true;
+-#ifdef CONFIG_SECURITY_SELINUX
+-	/*
+-	 * cred->security == NULL if security_cred_alloc_blank() or
+-	 * security_prepare_creds() returned an error.
+-	 */
+-	if (selinux_is_enabled() && cred->security) {
+-		if ((unsigned long) cred->security < PAGE_SIZE)
+-			return true;
+-		if ((*(u32 *)cred->security & 0xffffff00) ==
+-		    (POISON_FREE << 24 | POISON_FREE << 16 | POISON_FREE << 8))
+-			return true;
+-	}
+-#endif
+ 	return false;
+ }
+ EXPORT_SYMBOL(creds_are_invalid);
+diff --git a/kernel/exit.c b/kernel/exit.c
+index 120d4b4f0252..9a1692d36065 100644
+--- a/kernel/exit.c
++++ b/kernel/exit.c
+@@ -792,8 +792,6 @@ void __noreturn do_exit(long code)
+ 	 */
+ 	set_fs(USER_DS);
+ 
+-	security_task_exit(tsk);
+-
+ 	ptrace_event(PTRACE_EVENT_EXIT, code);
+ 
+ 	validate_creds_for_do_exit(tsk);
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index b93eb4eaf7ac..941661a6bbb0 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -264,9 +264,9 @@ static bool ptrace_has_cap(const struct cred *cred, struct user_namespace *ns,
+ 	int ret;
+ 
+ 	if (mode & PTRACE_MODE_NOAUDIT)
+-		ret = security_capable(cred, ns, CAP_SYS_PTRACE, CAP_OPT_NOAUDIT);
++		ret = security_capable(cred, ns, CAP_SYS_PTRACE);
+ 	else
+-		ret = security_capable(cred, ns, CAP_SYS_PTRACE, CAP_OPT_NONE);
++		ret = security_capable(cred, ns, CAP_SYS_PTRACE);
+ 
+ 	return ret == 0;
+ }
+diff --git a/kernel/seccomp.c b/kernel/seccomp.c
+index 56e69203b658..74a36438b6d1 100644
+--- a/kernel/seccomp.c
++++ b/kernel/seccomp.c
+@@ -383,8 +383,8 @@ static struct seccomp_filter *seccomp_prepare_filter(struct sock_fprog *fprog)
+ 	 * behavior of privileged children.
+ 	 */
+ 	if (!task_no_new_privs(current) &&
+-	    security_capable(current_cred(), current_user_ns(),
+-				     CAP_SYS_ADMIN, CAP_OPT_NOAUDIT) != 0)
++        security_capable_noaudit(current_cred(), current_user_ns(),
++				     CAP_SYS_ADMIN) != 0)
+ 		return ERR_PTR(-EACCES);
+ 
+ 	/* Allocate a new seccomp_filter */
+diff --git a/net/ipv4/cipso_ipv4.c b/net/ipv4/cipso_ipv4.c
+index f0165c5f376b..48b74173ea6d 100644
+--- a/net/ipv4/cipso_ipv4.c
++++ b/net/ipv4/cipso_ipv4.c
+@@ -128,7 +128,7 @@ int cipso_v4_rbm_strictvalid = 1;
+  * +----------+----------+
+  *
+  */
+-#define CIPSO_V4_TAG_LOC_BLEN         6
++#define CIPSO_V4_TAG_LOC_BLEN         (2 + sizeof(struct lsm_export))
+ 
+ /*
+  * Helper Functions
+@@ -1481,7 +1481,7 @@ static int cipso_v4_gentag_loc(const struct cipso_v4_doi *doi_def,
+ 
+ 	buffer[0] = CIPSO_V4_TAG_LOCAL;
+ 	buffer[1] = CIPSO_V4_TAG_LOC_BLEN;
+-	*(u32 *)&buffer[2] = secattr->attr.secid;
++    memcpy(&buffer[2], &secattr->attr.le, sizeof(secattr->attr.le));
+ 
+ 	return CIPSO_V4_TAG_LOC_BLEN;
+ }
+@@ -1501,7 +1501,7 @@ static int cipso_v4_parsetag_loc(const struct cipso_v4_doi *doi_def,
+ 				 const unsigned char *tag,
+ 				 struct netlbl_lsm_secattr *secattr)
+ {
+-	secattr->attr.secid = *(u32 *)&tag[2];
++    memcpy(&secattr->attr.le, &tag[2], sizeof(secattr->attr.le));
+ 	secattr->flags |= NETLBL_SECATTR_SECID;
+ 
+ 	return 0;
+diff --git a/net/ipv4/ip_sockglue.c b/net/ipv4/ip_sockglue.c
+index aa3fd61818c4..7de9ce993291 100644
+--- a/net/ipv4/ip_sockglue.c
++++ b/net/ipv4/ip_sockglue.c
+@@ -130,20 +130,20 @@ static void ip_cmsg_recv_checksum(struct msghdr *msg, struct sk_buff *skb,
+ 
+ static void ip_cmsg_recv_security(struct msghdr *msg, struct sk_buff *skb)
+ {
+-	char *secdata;
+-	u32 seclen, secid;
++    struct lsm_export le;
++    struct lsm_context lc;
+ 	int err;
+ 
+-	err = security_socket_getpeersec_dgram(NULL, skb, &secid);
++    err = security_socket_getpeersec_dgram(NULL, skb, &le);
+ 	if (err)
+ 		return;
+ 
+-	err = security_secid_to_secctx(secid, &secdata, &seclen);
++    err = security_secid_to_secctx(&le, &lc);
+ 	if (err)
+ 		return;
+ 
+-	put_cmsg(msg, SOL_IP, SCM_SECURITY, seclen, secdata);
+-	security_release_secctx(secdata, seclen);
++    put_cmsg(msg, SOL_IP, SCM_SECURITY, lc.len, lc.context);
++    security_release_secctx(&lc);
+ }
+ 
+ static void ip_cmsg_recv_dstaddr(struct msghdr *msg, struct sk_buff *skb)
+diff --git a/net/netfilter/nf_conntrack_netlink.c b/net/netfilter/nf_conntrack_netlink.c
+index 31fa94064a62..a6c67e683d97 100644
+--- a/net/netfilter/nf_conntrack_netlink.c
++++ b/net/netfilter/nf_conntrack_netlink.c
+@@ -331,10 +331,16 @@ static int ctnetlink_dump_mark(struct sk_buff *skb, const struct nf_conn *ct)
+ static int ctnetlink_dump_secctx(struct sk_buff *skb, const struct nf_conn *ct)
+ {
+ 	struct nlattr *nest_secctx;
+-	int len, ret;
+-	char *secctx;
++	int ret;
++    struct lsm_export le;
++    struct lsm_context lc;
+ 
+-	ret = security_secid_to_secctx(ct->secmark, &secctx, &len);
++    lsm_export_init(&le);
++    le.flags = LSM_EXPORT_SELINUX | LSM_EXPORT_SMACK;
++    le.selinux = ct->secmark;
++    le.smack = ct->secmark;
++
++    ret = security_secid_to_secctx(&le, &lc);
+ 	if (ret)
+ 		return 0;
+ 
+@@ -343,13 +349,13 @@ static int ctnetlink_dump_secctx(struct sk_buff *skb, const struct nf_conn *ct)
+ 	if (!nest_secctx)
+ 		goto nla_put_failure;
+ 
+-	if (nla_put_string(skb, CTA_SECCTX_NAME, secctx))
++    if (nla_put_string(skb, CTA_SECCTX_NAME, lc.context))
+ 		goto nla_put_failure;
+ 	nla_nest_end(skb, nest_secctx);
+ 
+ 	ret = 0;
+ nla_put_failure:
+-	security_release_secctx(secctx, len);
++    security_release_secctx(&lc);
+ 	return ret;
+ }
+ #else
+@@ -623,13 +629,20 @@ static inline int ctnetlink_secctx_size(const struct nf_conn *ct)
+ {
+ #ifdef CONFIG_NF_CONNTRACK_SECMARK
+ 	int len, ret;
++    struct lsm_export le;
++    struct lsm_context lc;
++
++    lsm_export_init(&le);
++    le.flags = LSM_EXPORT_SELINUX | LSM_EXPORT_SMACK | LSM_EXPORT_LENGTH;
++    le.selinux = ct->secmark;
++    le.smack = ct->secmark;
+ 
+-	ret = security_secid_to_secctx(ct->secmark, NULL, &len);
++    ret = security_secid_to_secctx(&le, &lc);
+ 	if (ret)
+ 		return 0;
+ 
+ 	return nla_total_size(0) /* CTA_SECCTX */
+-	       + nla_total_size(sizeof(char) * len); /* CTA_SECCTX_NAME */
++           + nla_total_size(sizeof(char) * lc.len); /* CTA_SECCTX_NAME */
+ #else
+ 	return 0;
+ #endif
+diff --git a/net/netfilter/nf_conntrack_standalone.c b/net/netfilter/nf_conntrack_standalone.c
+index 13279f683da9..e04f4d5d2a94 100644
+--- a/net/netfilter/nf_conntrack_standalone.c
++++ b/net/netfilter/nf_conntrack_standalone.c
+@@ -168,17 +168,23 @@ static void ct_seq_stop(struct seq_file *s, void *v)
+ #ifdef CONFIG_NF_CONNTRACK_SECMARK
+ static void ct_show_secctx(struct seq_file *s, const struct nf_conn *ct)
+ {
+-	int ret;
+-	u32 len;
+-	char *secctx;
++    int ret;
++    struct lsm_export le;
++    struct lsm_context lc;
+ 
+-	ret = security_secid_to_secctx(ct->secmark, &secctx, &len);
+-	if (ret)
+-		return;
++    /* Whichever LSM may be using the secmark */
++    lsm_export_init(&le);
++    le.flags = LSM_EXPORT_SELINUX | LSM_EXPORT_SMACK;
++    le.selinux = ct->secmark;
++    le.smack = ct->secmark;
++
++    ret = security_secid_to_secctx(&le, &lc);
++    if (ret)
++        return;
+ 
+-	seq_printf(s, "secctx=%s ", secctx);
++    seq_printf(s, "secctx=%s ", lc.context);
+ 
+-	security_release_secctx(secctx, len);
++    security_release_secctx(&lc);
+ }
+ #else
+ static inline void ct_show_secctx(struct seq_file *s, const struct nf_conn *ct)
+diff --git a/net/netfilter/nfnetlink_queue.c b/net/netfilter/nfnetlink_queue.c
+index d33094f4ec41..b945686dc647 100644
+--- a/net/netfilter/nfnetlink_queue.c
++++ b/net/netfilter/nfnetlink_queue.c
+@@ -305,21 +305,27 @@ static int nfqnl_put_sk_uidgid(struct sk_buff *skb, struct sock *sk)
+ 	return -1;
+ }
+ 
+-static u32 nfqnl_get_sk_secctx(struct sk_buff *skb, char **secdata)
++static void nfqnl_get_sk_secctx(struct sk_buff *skb, struct lsm_context *cp)
+ {
+-	u32 seclen = 0;
+ #if IS_ENABLED(CONFIG_NETWORK_SECMARK)
+-	if (!skb || !sk_fullsock(skb->sk))
+-		return 0;
++    struct lsm_export le;
++
++    if (!skb || !sk_fullsock(skb->sk))
++        return;
+ 
+-	read_lock_bh(&skb->sk->sk_callback_lock);
++    read_lock_bh(&skb->sk->sk_callback_lock);
+ 
+-	if (skb->secmark)
+-		security_secid_to_secctx(skb->secmark, secdata, &seclen);
++    if (skb->secmark) {
++        /* Whichever LSM may be using the secmark */
++        lsm_export_init(&le);
++        le.flags = LSM_EXPORT_SELINUX | LSM_EXPORT_SMACK;
++        le.selinux = skb->secmark;
++        le.smack = skb->secmark;
++        security_secid_to_secctx(&le, cp);
++    }
+ 
+-	read_unlock_bh(&skb->sk->sk_callback_lock);
++    read_unlock_bh(&skb->sk->sk_callback_lock);
+ #endif
+-	return seclen;
+ }
+ 
+ static u32 nfqnl_get_bridge_size(struct nf_queue_entry *entry)
+@@ -395,8 +401,7 @@ nfqnl_build_packet_message(struct net *net, struct nfqnl_instance *queue,
+ 	enum ip_conntrack_info uninitialized_var(ctinfo);
+ 	struct nfnl_ct_hook *nfnl_ct;
+ 	bool csum_verify;
+-	char *secdata = NULL;
+-	u32 seclen = 0;
++    struct lsm_context lc;
+ 
+ 	size =    nlmsg_total_size(sizeof(struct nfgenmsg))
+ 		+ nla_total_size(sizeof(struct nfqnl_msg_packet_hdr))
+@@ -462,9 +467,10 @@ nfqnl_build_packet_message(struct net *net, struct nfqnl_instance *queue,
+ 	}
+ 
+ 	if ((queue->flags & NFQA_CFG_F_SECCTX) && entskb->sk) {
+-		seclen = nfqnl_get_sk_secctx(entskb, &secdata);
+-		if (seclen)
+-			size += nla_total_size(seclen);
++        nfqnl_get_sk_secctx(entskb, &lc);
++        if (lc.len)
++            size += nla_total_size(lc.len);
++
+ 	}
+ 
+ 	skb = alloc_skb(size, GFP_ATOMIC);
+@@ -597,7 +603,7 @@ nfqnl_build_packet_message(struct net *net, struct nfqnl_instance *queue,
+ 	    nfqnl_put_sk_uidgid(skb, entskb->sk) < 0)
+ 		goto nla_put_failure;
+ 
+-	if (seclen && nla_put(skb, NFQA_SECCTX, seclen, secdata))
++    if (lc.len && nla_put(skb, NFQA_SECCTX, lc.len, lc.context))
+ 		goto nla_put_failure;
+ 
+ 	if (ct && nfnl_ct->build(skb, ct, ctinfo, NFQA_CT, NFQA_CT_INFO) < 0)
+@@ -625,8 +631,7 @@ nfqnl_build_packet_message(struct net *net, struct nfqnl_instance *queue,
+ 	}
+ 
+ 	nlh->nlmsg_len = skb->len;
+-	if (seclen)
+-		security_release_secctx(secdata, seclen);
++    security_release_secctx(&lc);
+ 	return skb;
+ 
+ nla_put_failure:
+@@ -634,8 +639,7 @@ nfqnl_build_packet_message(struct net *net, struct nfqnl_instance *queue,
+ 	kfree_skb(skb);
+ 	net_err_ratelimited("nf_queue: error creating packet message\n");
+ nlmsg_failure:
+-	if (seclen)
+-		security_release_secctx(secdata, seclen);
++    security_release_secctx(&lc);
+ 	return NULL;
+ }
+ 
+diff --git a/net/netfilter/xt_SECMARK.c b/net/netfilter/xt_SECMARK.c
+index 4ad5fe27e08b..2dc41641087f 100644
+--- a/net/netfilter/xt_SECMARK.c
++++ b/net/netfilter/xt_SECMARK.c
+@@ -51,34 +51,40 @@ secmark_tg(struct sk_buff *skb, const struct xt_action_param *par)
+ 
+ static int checkentry_lsm(struct xt_secmark_target_info *info)
+ {
+-	int err;
+-
+-	info->secctx[SECMARK_SECCTX_MAX - 1] = '\0';
+-	info->secid = 0;
+-
+-	err = security_secctx_to_secid(info->secctx, strlen(info->secctx),
+-				       &info->secid);
+-	if (err) {
+-		if (err == -EINVAL)
+-			pr_info_ratelimited("invalid security context \'%s\'\n",
+-					    info->secctx);
+-		return err;
+-	}
++    struct lsm_export le;
++    struct lsm_context lc;
++    int err;
++
++    info->secctx[SECMARK_SECCTX_MAX - 1] = '\0';
++    info->secid = 0;
++
++    lsm_export_init(&le);
++    lc.context = info->secctx;
++    lc.len = strlen(info->secctx);
++    err = security_secctx_to_secid(&lc, &le);
++    if (err) {
++        if (err == -EINVAL)
++            pr_info_ratelimited("invalid security context \'%s\'\n",
++                        info->secctx);
++        return err;
++    }
++
++    info->secid = lsm_export_one_secid(&le);
++    if (!info->secid) {
++        pr_info_ratelimited("unable to map security context \'%s\'\n",
++                    info->secctx);
++        return -ENOENT;
++    }
++
++    err = security_secmark_relabel_packet(info->secid);
++    if (err) {
++        pr_info_ratelimited("unable to obtain relabeling permission\n");
++        return err;
++    }
++
++    security_secmark_refcount_inc();
++    return 0;
+ 
+-	if (!info->secid) {
+-		pr_info_ratelimited("unable to map security context \'%s\'\n",
+-				    info->secctx);
+-		return -ENOENT;
+-	}
+-
+-	err = security_secmark_relabel_packet(info->secid);
+-	if (err) {
+-		pr_info_ratelimited("unable to obtain relabeling permission\n");
+-		return err;
+-	}
+-
+-	security_secmark_refcount_inc();
+-	return 0;
+ }
+ 
+ static int secmark_tg_check(const struct xt_tgchk_param *par)
+diff --git a/net/netlabel/netlabel_kapi.c b/net/netlabel/netlabel_kapi.c
+index ee3e5b6471a6..f8052f8612a2 100644
+--- a/net/netlabel/netlabel_kapi.c
++++ b/net/netlabel/netlabel_kapi.c
+@@ -224,7 +224,7 @@ int netlbl_cfg_unlbl_static_add(struct net *net,
+ 				const void *addr,
+ 				const void *mask,
+ 				u16 family,
+-				u32 secid,
++                struct lsm_export *l,
+ 				struct netlbl_audit *audit_info)
+ {
+ 	u32 addr_len;
+@@ -243,8 +243,7 @@ int netlbl_cfg_unlbl_static_add(struct net *net,
+ 	}
+ 
+ 	return netlbl_unlhsh_add(net,
+-				 dev_name, addr, mask, addr_len,
+-				 secid, audit_info);
++                 dev_name, addr, mask, addr_len, l, audit_info);
+ }
+ 
+ /**
+diff --git a/net/netlabel/netlabel_unlabeled.c b/net/netlabel/netlabel_unlabeled.c
+index c92894c3e40a..55fa5df2645d 100644
+--- a/net/netlabel/netlabel_unlabeled.c
++++ b/net/netlabel/netlabel_unlabeled.c
+@@ -80,7 +80,7 @@ struct netlbl_unlhsh_tbl {
+ #define netlbl_unlhsh_addr4_entry(iter) \
+ 	container_of(iter, struct netlbl_unlhsh_addr4, list)
+ struct netlbl_unlhsh_addr4 {
+-	u32 secid;
++    struct lsm_export le;
+ 
+ 	struct netlbl_af4list list;
+ 	struct rcu_head rcu;
+@@ -88,7 +88,7 @@ struct netlbl_unlhsh_addr4 {
+ #define netlbl_unlhsh_addr6_entry(iter) \
+ 	container_of(iter, struct netlbl_unlhsh_addr6, list)
+ struct netlbl_unlhsh_addr6 {
+-	u32 secid;
++	struct lsm_export le;
+ 
+ 	struct netlbl_af6list list;
+ 	struct rcu_head rcu;
+@@ -244,7 +244,7 @@ static struct netlbl_unlhsh_iface *netlbl_unlhsh_search_iface(int ifindex)
+ static int netlbl_unlhsh_add_addr4(struct netlbl_unlhsh_iface *iface,
+ 				   const struct in_addr *addr,
+ 				   const struct in_addr *mask,
+-				   u32 secid)
++				   struct lsm_export *l)
+ {
+ 	int ret_val;
+ 	struct netlbl_unlhsh_addr4 *entry;
+@@ -256,7 +256,7 @@ static int netlbl_unlhsh_add_addr4(struct netlbl_unlhsh_iface *iface,
+ 	entry->list.addr = addr->s_addr & mask->s_addr;
+ 	entry->list.mask = mask->s_addr;
+ 	entry->list.valid = 1;
+-	entry->secid = secid;
++	entry->le = *l;
+ 
+ 	spin_lock(&netlbl_unlhsh_lock);
+ 	ret_val = netlbl_af4list_add(&entry->list, &iface->addr4_list);
+@@ -284,7 +284,7 @@ static int netlbl_unlhsh_add_addr4(struct netlbl_unlhsh_iface *iface,
+ static int netlbl_unlhsh_add_addr6(struct netlbl_unlhsh_iface *iface,
+ 				   const struct in6_addr *addr,
+ 				   const struct in6_addr *mask,
+-				   u32 secid)
++				   struct lsm_export *l)
+ {
+ 	int ret_val;
+ 	struct netlbl_unlhsh_addr6 *entry;
+@@ -300,7 +300,7 @@ static int netlbl_unlhsh_add_addr6(struct netlbl_unlhsh_iface *iface,
+ 	entry->list.addr.s6_addr32[3] &= mask->s6_addr32[3];
+ 	entry->list.mask = *mask;
+ 	entry->list.valid = 1;
+-	entry->secid = secid;
++	entry->le = *l;
+ 
+ 	spin_lock(&netlbl_unlhsh_lock);
+ 	ret_val = netlbl_af6list_add(&entry->list, &iface->addr6_list);
+@@ -379,7 +379,7 @@ int netlbl_unlhsh_add(struct net *net,
+ 		      const void *addr,
+ 		      const void *mask,
+ 		      u32 addr_len,
+-		      u32 secid,
++		      struct lsm_export *l,
+ 		      struct netlbl_audit *audit_info)
+ {
+ 	int ret_val;
+@@ -387,8 +387,6 @@ int netlbl_unlhsh_add(struct net *net,
+ 	struct net_device *dev;
+ 	struct netlbl_unlhsh_iface *iface;
+ 	struct audit_buffer *audit_buf = NULL;
+-	char *secctx = NULL;
+-	u32 secctx_len;
+ 
+ 	if (addr_len != sizeof(struct in_addr) &&
+ 	    addr_len != sizeof(struct in6_addr))
+@@ -421,7 +419,7 @@ int netlbl_unlhsh_add(struct net *net,
+ 		const struct in_addr *addr4 = addr;
+ 		const struct in_addr *mask4 = mask;
+ 
+-		ret_val = netlbl_unlhsh_add_addr4(iface, addr4, mask4, secid);
++		ret_val = netlbl_unlhsh_add_addr4(iface, addr4, mask4, l);
+ 		if (audit_buf != NULL)
+ 			netlbl_af4list_audit_addr(audit_buf, 1,
+ 						  dev_name,
+@@ -434,7 +432,7 @@ int netlbl_unlhsh_add(struct net *net,
+ 		const struct in6_addr *addr6 = addr;
+ 		const struct in6_addr *mask6 = mask;
+ 
+-		ret_val = netlbl_unlhsh_add_addr6(iface, addr6, mask6, secid);
++		ret_val = netlbl_unlhsh_add_addr6(iface, addr6, mask6, l);
+ 		if (audit_buf != NULL)
+ 			netlbl_af6list_audit_addr(audit_buf, 1,
+ 						  dev_name,
+@@ -451,11 +449,10 @@ int netlbl_unlhsh_add(struct net *net,
+ unlhsh_add_return:
+ 	rcu_read_unlock();
+ 	if (audit_buf != NULL) {
+-		if (security_secid_to_secctx(secid,
+-					     &secctx,
+-					     &secctx_len) == 0) {
+-			audit_log_format(audit_buf, " sec_obj=%s", secctx);
+-			security_release_secctx(secctx, secctx_len);
++        struct lsm_context lc;
++        if (security_secid_to_secctx(l, &lc) == 0) {
++            audit_log_format(audit_buf, " sec_obj=%s", lc.context);
++            security_release_secctx(&lc);
+ 		}
+ 		audit_log_format(audit_buf, " res=%u", ret_val == 0 ? 1 : 0);
+ 		audit_log_end(audit_buf);
+@@ -486,8 +483,6 @@ static int netlbl_unlhsh_remove_addr4(struct net *net,
+ 	struct netlbl_unlhsh_addr4 *entry;
+ 	struct audit_buffer *audit_buf;
+ 	struct net_device *dev;
+-	char *secctx;
+-	u32 secctx_len;
+ 
+ 	spin_lock(&netlbl_unlhsh_lock);
+ 	list_entry = netlbl_af4list_remove(addr->s_addr, mask->s_addr,
+@@ -501,6 +496,7 @@ static int netlbl_unlhsh_remove_addr4(struct net *net,
+ 	audit_buf = netlbl_audit_start_common(AUDIT_MAC_UNLBL_STCDEL,
+ 					      audit_info);
+ 	if (audit_buf != NULL) {
++        struct lsm_context lc;
+ 		dev = dev_get_by_index(net, iface->ifindex);
+ 		netlbl_af4list_audit_addr(audit_buf, 1,
+ 					  (dev != NULL ? dev->name : NULL),
+@@ -508,10 +504,9 @@ static int netlbl_unlhsh_remove_addr4(struct net *net,
+ 		if (dev != NULL)
+ 			dev_put(dev);
+ 		if (entry != NULL &&
+-		    security_secid_to_secctx(entry->secid,
+-					     &secctx, &secctx_len) == 0) {
+-			audit_log_format(audit_buf, " sec_obj=%s", secctx);
+-			security_release_secctx(secctx, secctx_len);
++            security_secid_to_secctx(&entry->le, &lc) == 0) {
++                audit_log_format(audit_buf, " sec_obj=%s", lc.context);
++                security_release_secctx(&lc);
+ 		}
+ 		audit_log_format(audit_buf, " res=%u", entry != NULL ? 1 : 0);
+ 		audit_log_end(audit_buf);
+@@ -548,8 +543,6 @@ static int netlbl_unlhsh_remove_addr6(struct net *net,
+ 	struct netlbl_unlhsh_addr6 *entry;
+ 	struct audit_buffer *audit_buf;
+ 	struct net_device *dev;
+-	char *secctx;
+-	u32 secctx_len;
+ 
+ 	spin_lock(&netlbl_unlhsh_lock);
+ 	list_entry = netlbl_af6list_remove(addr, mask, &iface->addr6_list);
+@@ -562,6 +555,7 @@ static int netlbl_unlhsh_remove_addr6(struct net *net,
+ 	audit_buf = netlbl_audit_start_common(AUDIT_MAC_UNLBL_STCDEL,
+ 					      audit_info);
+ 	if (audit_buf != NULL) {
++        struct lsm_context lc;
+ 		dev = dev_get_by_index(net, iface->ifindex);
+ 		netlbl_af6list_audit_addr(audit_buf, 1,
+ 					  (dev != NULL ? dev->name : NULL),
+@@ -569,10 +563,10 @@ static int netlbl_unlhsh_remove_addr6(struct net *net,
+ 		if (dev != NULL)
+ 			dev_put(dev);
+ 		if (entry != NULL &&
+-		    security_secid_to_secctx(entry->secid,
+-					     &secctx, &secctx_len) == 0) {
+-			audit_log_format(audit_buf, " sec_obj=%s", secctx);
+-			security_release_secctx(secctx, secctx_len);
++            security_secid_to_secctx(&entry->le, &lc) == 0) {
++                audit_log_format(audit_buf, " sec_obj=%s", lc.context);
++                security_release_secctx(&lc);
++
+ 		}
+ 		audit_log_format(audit_buf, " res=%u", entry != NULL ? 1 : 0);
+ 		audit_log_end(audit_buf);
+@@ -895,7 +889,8 @@ static int netlbl_unlabel_staticadd(struct sk_buff *skb,
+ 	void *addr;
+ 	void *mask;
+ 	u32 addr_len;
+-	u32 secid;
++    struct lsm_export le;
++    struct lsm_context lc;
+ 	struct netlbl_audit audit_info;
+ 
+ 	/* Don't allow users to add both IPv4 and IPv6 addresses for a
+@@ -916,15 +911,14 @@ static int netlbl_unlabel_staticadd(struct sk_buff *skb,
+ 	if (ret_val != 0)
+ 		return ret_val;
+ 	dev_name = nla_data(info->attrs[NLBL_UNLABEL_A_IFACE]);
+-	ret_val = security_secctx_to_secid(
+-		                  nla_data(info->attrs[NLBL_UNLABEL_A_SECCTX]),
+-				  nla_len(info->attrs[NLBL_UNLABEL_A_SECCTX]),
+-				  &secid);
++    lc.context = nla_data(info->attrs[NLBL_UNLABEL_A_SECCTX]);
++    lc.len = nla_len(info->attrs[NLBL_UNLABEL_A_SECCTX]);
++    ret_val = security_secctx_to_secid(&lc, &le);
+ 	if (ret_val != 0)
+ 		return ret_val;
+ 
+ 	return netlbl_unlhsh_add(&init_net,
+-				 dev_name, addr, mask, addr_len, secid,
++                 dev_name, addr, mask, addr_len, &le,
+ 				 &audit_info);
+ }
+ 
+@@ -946,7 +940,8 @@ static int netlbl_unlabel_staticadddef(struct sk_buff *skb,
+ 	void *addr;
+ 	void *mask;
+ 	u32 addr_len;
+-	u32 secid;
++    struct lsm_export le;
++    struct lsm_context lc;
+ 	struct netlbl_audit audit_info;
+ 
+ 	/* Don't allow users to add both IPv4 and IPv6 addresses for a
+@@ -965,15 +960,15 @@ static int netlbl_unlabel_staticadddef(struct sk_buff *skb,
+ 	ret_val = netlbl_unlabel_addrinfo_get(info, &addr, &mask, &addr_len);
+ 	if (ret_val != 0)
+ 		return ret_val;
+-	ret_val = security_secctx_to_secid(
+-		                  nla_data(info->attrs[NLBL_UNLABEL_A_SECCTX]),
+-				  nla_len(info->attrs[NLBL_UNLABEL_A_SECCTX]),
+-				  &secid);
++    lc.context = nla_data(info->attrs[NLBL_UNLABEL_A_SECCTX]);
++    lc.len = nla_len(info->attrs[NLBL_UNLABEL_A_SECCTX]);
++    ret_val = security_secctx_to_secid(&lc, &le);
++
+ 	if (ret_val != 0)
+ 		return ret_val;
+ 
+ 	return netlbl_unlhsh_add(&init_net,
+-				 NULL, addr, mask, addr_len, secid,
++				 NULL, addr, mask, addr_len, &le,
+ 				 &audit_info);
+ }
+ 
+@@ -1085,9 +1080,8 @@ static int netlbl_unlabel_staticlist_gen(u32 cmd,
+ 	struct netlbl_unlhsh_walk_arg *cb_arg = arg;
+ 	struct net_device *dev;
+ 	void *data;
+-	u32 secid;
+-	char *secctx;
+-	u32 secctx_len;
++    struct lsm_export *lep;
++    struct lsm_context lc;
+ 
+ 	data = genlmsg_put(cb_arg->skb, NETLINK_CB(cb_arg->nl_cb->skb).portid,
+ 			   cb_arg->seq, &netlbl_unlabel_gnl_family,
+@@ -1125,7 +1119,7 @@ static int netlbl_unlabel_staticlist_gen(u32 cmd,
+ 		if (ret_val != 0)
+ 			goto list_cb_failure;
+ 
+-		secid = addr4->secid;
++        lep = &addr4->le;
+ 	} else {
+ 		ret_val = nla_put_in6_addr(cb_arg->skb,
+ 					   NLBL_UNLABEL_A_IPV6ADDR,
+@@ -1139,17 +1133,17 @@ static int netlbl_unlabel_staticlist_gen(u32 cmd,
+ 		if (ret_val != 0)
+ 			goto list_cb_failure;
+ 
+-		secid = addr6->secid;
++        lep = &addr6->le;
+ 	}
+ 
+-	ret_val = security_secid_to_secctx(secid, &secctx, &secctx_len);
++    ret_val = security_secid_to_secctx(lep, &lc);
+ 	if (ret_val != 0)
+ 		goto list_cb_failure;
+ 	ret_val = nla_put(cb_arg->skb,
+ 			  NLBL_UNLABEL_A_SECCTX,
+-			  secctx_len,
+-			  secctx);
+-	security_release_secctx(secctx, secctx_len);
++              lc.len,
++              lc.context);
++    security_release_secctx(&lc);
+ 	if (ret_val != 0)
+ 		goto list_cb_failure;
+ 
+@@ -1487,26 +1481,30 @@ int netlbl_unlabel_getattr(const struct sk_buff *skb,
+ 	case PF_INET: {
+ 		struct iphdr *hdr4;
+ 		struct netlbl_af4list *addr4;
++        struct lsm_export *lep;
+ 
+ 		hdr4 = ip_hdr(skb);
+ 		addr4 = netlbl_af4list_search(hdr4->saddr,
+ 					      &iface->addr4_list);
+ 		if (addr4 == NULL)
+ 			goto unlabel_getattr_nolabel;
+-		secattr->attr.secid = netlbl_unlhsh_addr4_entry(addr4)->secid;
++        lep = &netlbl_unlhsh_addr4_entry(addr4)->le;
++        secattr->attr.le = *lep;
+ 		break;
+ 	}
+ #if IS_ENABLED(CONFIG_IPV6)
+ 	case PF_INET6: {
+ 		struct ipv6hdr *hdr6;
+ 		struct netlbl_af6list *addr6;
++        struct lsm_export *lep;
+ 
+ 		hdr6 = ipv6_hdr(skb);
+ 		addr6 = netlbl_af6list_search(&hdr6->saddr,
+ 					      &iface->addr6_list);
+ 		if (addr6 == NULL)
+ 			goto unlabel_getattr_nolabel;
+-		secattr->attr.secid = netlbl_unlhsh_addr6_entry(addr6)->secid;
++        lep = &netlbl_unlhsh_addr6_entry(addr6)->le;
++        secattr->attr.le = *lep;
+ 		break;
+ 	}
+ #endif /* IPv6 */
+@@ -1544,7 +1542,7 @@ int __init netlbl_unlabel_defconf(void)
+ 	/* Only the kernel is allowed to call this function and the only time
+ 	 * it is called is at bootup before the audit subsystem is reporting
+ 	 * messages so don't worry to much about these values. */
+-	security_task_getsecid(current, &audit_info.secid);
++    security_task_getsecid(current, &audit_info.le);
+ 	audit_info.loginuid = GLOBAL_ROOT_UID;
+ 	audit_info.sessionid = 0;
+ 
+diff --git a/net/netlabel/netlabel_unlabeled.h b/net/netlabel/netlabel_unlabeled.h
+index 3a9e5dc9511b..797e58c52751 100644
+--- a/net/netlabel/netlabel_unlabeled.h
++++ b/net/netlabel/netlabel_unlabeled.h
+@@ -225,7 +225,7 @@ int netlbl_unlhsh_add(struct net *net,
+ 		      const void *addr,
+ 		      const void *mask,
+ 		      u32 addr_len,
+-		      u32 secid,
++              struct lsm_export *l,
+ 		      struct netlbl_audit *audit_info);
+ int netlbl_unlhsh_remove(struct net *net,
+ 			 const char *dev_name,
+diff --git a/net/netlabel/netlabel_user.c b/net/netlabel/netlabel_user.c
+index 4676f5bb16ae..81341edca0f2 100644
+--- a/net/netlabel/netlabel_user.c
++++ b/net/netlabel/netlabel_user.c
+@@ -97,28 +97,25 @@ int __init netlbl_netlink_init(void)
+ struct audit_buffer *netlbl_audit_start_common(int type,
+ 					       struct netlbl_audit *audit_info)
+ {
+-	struct audit_buffer *audit_buf;
+-	char *secctx;
+-	u32 secctx_len;
+-
+-	if (audit_enabled == AUDIT_OFF)
+-		return NULL;
+-
+-	audit_buf = audit_log_start(audit_context(), GFP_ATOMIC, type);
+-	if (audit_buf == NULL)
+-		return NULL;
+-
+-	audit_log_format(audit_buf, "netlabel: auid=%u ses=%u",
+-			 from_kuid(&init_user_ns, audit_info->loginuid),
+-			 audit_info->sessionid);
+-
+-	if (audit_info->secid != 0 &&
+-	    security_secid_to_secctx(audit_info->secid,
+-				     &secctx,
+-				     &secctx_len) == 0) {
+-		audit_log_format(audit_buf, " subj=%s", secctx);
+-		security_release_secctx(secctx, secctx_len);
+-	}
+-
+-	return audit_buf;
++    struct audit_buffer *audit_buf;
++    struct lsm_context lc;
++
++    if (audit_enabled == AUDIT_OFF)
++        return NULL;
++
++    audit_buf = audit_log_start(audit_context(), GFP_ATOMIC, type);
++    if (audit_buf == NULL)
++        return NULL;
++
++    audit_log_format(audit_buf, "netlabel: auid=%u ses=%u",
++             from_kuid(&init_user_ns, audit_info->loginuid),
++             audit_info->sessionid);
++
++    if (lsm_export_any(&audit_info->le) &&
++        security_secid_to_secctx(&audit_info->le, &lc) == 0) {
++        audit_log_format(audit_buf, " subj=%s", lc.context);
++        security_release_secctx(&lc);
++    }
++
++    return audit_buf;
+ }
+diff --git a/net/netlabel/netlabel_user.h b/net/netlabel/netlabel_user.h
+index 4a397cde1a48..8ce82d6aa7bf 100644
+--- a/net/netlabel/netlabel_user.h
++++ b/net/netlabel/netlabel_user.h
+@@ -48,7 +48,7 @@
+ static inline void netlbl_netlink_auditinfo(struct sk_buff *skb,
+ 					    struct netlbl_audit *audit_info)
+ {
+-	security_task_getsecid(current, &audit_info->secid);
++    security_task_getsecid(current, &audit_info->le);
+ 	audit_info->loginuid = audit_get_loginuid(current);
+ 	audit_info->sessionid = audit_get_sessionid(current);
+ }
+diff --git a/net/unix/af_unix.c b/net/unix/af_unix.c
+index 2fef86f695d9..f2d3657154f5 100644
+--- a/net/unix/af_unix.c
++++ b/net/unix/af_unix.c
+@@ -141,17 +141,21 @@ static struct hlist_head *unix_sockets_unbound(void *addr)
+ #ifdef CONFIG_SECURITY_NETWORK
+ static void unix_get_secdata(struct scm_cookie *scm, struct sk_buff *skb)
+ {
+-	UNIXCB(skb).secid = scm->secid;
++    struct lsm_export *ble = lsm_export_skb(skb);
++
++    *ble = scm->le;
+ }
+ 
+ static inline void unix_set_secdata(struct scm_cookie *scm, struct sk_buff *skb)
+ {
+-	scm->secid = UNIXCB(skb).secid;
++    struct lsm_export *ble = lsm_export_skb(skb);
++
++    scm->le = *ble;
+ }
+ 
+ static inline bool unix_secdata_eq(struct scm_cookie *scm, struct sk_buff *skb)
+ {
+-	return (scm->secid == UNIXCB(skb).secid);
++    return lsm_export_equal(&scm->le, lsm_export_skb(skb));
+ }
+ #else
+ static inline void unix_get_secdata(struct scm_cookie *scm, struct sk_buff *skb)
+diff --git a/security/Kconfig b/security/Kconfig
+index 0cde3e31bfd0..4accf6cccd32 100644
+--- a/security/Kconfig
++++ b/security/Kconfig
+@@ -18,15 +18,6 @@ config SECURITY_DMESG_RESTRICT
+ 
+ 	  If you are unsure how to answer this question, answer N.
+ 
+-config SECURITY_PERF_EVENTS_RESTRICT
+-	bool "Restrict unprivileged use of performance events"
+-	depends on PERF_EVENTS
+-	help
+-	  If you say Y here, the kernel.perf_event_paranoid sysctl
+-	  will be set to 3 by default, and no unprivileged use of the
+-	  perf_event_open syscall will be permitted unless it is
+-	  changed.
+-
+ config SECURITY
+ 	bool "Enable different security models"
+ 	depends on SYSFS
+@@ -251,50 +242,15 @@ source security/container/Kconfig
+ 
+ source security/integrity/Kconfig
+ 
+-choice
+-	prompt "Default security module"
+-	default DEFAULT_SECURITY_SELINUX if SECURITY_SELINUX
+-	default DEFAULT_SECURITY_SMACK if SECURITY_SMACK
+-	default DEFAULT_SECURITY_TOMOYO if SECURITY_TOMOYO
+-	default DEFAULT_SECURITY_APPARMOR if SECURITY_APPARMOR
+-	default DEFAULT_SECURITY_DAC
+-
++config LSM
++	string "Ordered list of enabled LSMs"
++	default "yama,loadpin,integrity,apparmor,selinux"
+ 	help
+-	  Select the security module that will be used by default if the
+-	  kernel parameter security= is not specified.
+-
+-	config DEFAULT_SECURITY_SELINUX
+-		bool "SELinux" if SECURITY_SELINUX=y
+-
+-	config DEFAULT_SECURITY_SMACK
+-		bool "Simplified Mandatory Access Control" if SECURITY_SMACK=y
+-
+-	config DEFAULT_SECURITY_TOMOYO
+-		bool "TOMOYO" if SECURITY_TOMOYO=y
++	  A comma-separated list of LSMs, in initialization order.
++	  Any LSMs left off this list will be ignored. This can be
++	  controlled at boot with the "lsm=" parameter.
+ 
+-	config DEFAULT_SECURITY_APPARMOR
+-		bool "AppArmor" if SECURITY_APPARMOR=y
+-
+-	config DEFAULT_SECURITY_DAC
+-		bool "Unix Discretionary Access Controls"
+-
+-endchoice
+-
+-config DEFAULT_SECURITY
+-	string
+-	default "selinux" if DEFAULT_SECURITY_SELINUX
+-	default "smack" if DEFAULT_SECURITY_SMACK
+-	default "tomoyo" if DEFAULT_SECURITY_TOMOYO
+-	default "apparmor" if DEFAULT_SECURITY_APPARMOR
+-	default "" if DEFAULT_SECURITY_DAC
+-
+-config ARCH_HAS_ALT_SYSCALL
+-	def_bool n
+-
+-config ALT_SYSCALL
+-	bool "Alternate syscall table support"
+-	depends on ARCH_HAS_ALT_SYSCALL
+-	help
+-	  Allow syscall table to be swapped on a running process.
++	  If unsure, leave this as the default.
+ 
+ endmenu
++
+diff --git a/security/Makefile b/security/Makefile
+index 3c46e4b1f75b..f191425d4178 100644
+--- a/security/Makefile
++++ b/security/Makefile
+@@ -12,7 +12,7 @@ subdir-$(CONFIG_SECURITY_YAMA)		+= yama
+ subdir-$(CONFIG_SECURITY_LOADPIN)	+= loadpin
+ subdir-$(CONFIG_SECURITY_SAFESETID)	+= safesetid
+ subdir-$(CONFIG_SECURITY_CHROMIUMOS)	+= chromiumos
+-subdir-$(CONFIG_SECURITY_CONTAINER_MONITOR) += container
++subdir-$(CONFIG_SECURITY_CONTAINER_MONITOR)	+= container
+ 
+ # always enable default capabilities
+ obj-y					+= commoncap.o
+@@ -21,7 +21,7 @@ obj-$(CONFIG_MMU)			+= min_addr.o
+ # Object file lists
+ obj-$(CONFIG_SECURITY)			+= security.o
+ obj-$(CONFIG_SECURITYFS)		+= inode.o
+-obj-$(CONFIG_SECURITY_CHROMIUMOS)	+= chromiumos/
++obj-$(CONFIG_SECURITY_CHROMIUMOS)		+= chromiumos/
+ obj-$(CONFIG_SECURITY_SELINUX)		+= selinux/
+ obj-$(CONFIG_SECURITY_SMACK)		+= smack/
+ obj-$(CONFIG_AUDIT)			+= lsm_audit.o
+@@ -29,9 +29,9 @@ obj-$(CONFIG_SECURITY_TOMOYO)		+= tomoyo/
+ obj-$(CONFIG_SECURITY_APPARMOR)		+= apparmor/
+ obj-$(CONFIG_SECURITY_YAMA)		+= yama/
+ obj-$(CONFIG_SECURITY_LOADPIN)		+= loadpin/
+-obj-$(CONFIG_SECURITY_SAFESETID)	+= safesetid/
++obj-$(CONFIG_SECURITY_SAFESETID)		+= safesetid/
+ obj-$(CONFIG_CGROUP_DEVICE)		+= device_cgroup.o
+-obj-$(CONFIG_SECURITY_CONTAINER_MONITOR) += container/
++obj-$(CONFIG_SECURITY_CONTAINER_MONITOR)		+= container/
+ 
+ # Object integrity file lists
+ subdir-$(CONFIG_INTEGRITY)		+= integrity
+diff --git a/security/apparmor/Kconfig b/security/apparmor/Kconfig
+index b6b68a7750ce..3de21f46c82a 100644
+--- a/security/apparmor/Kconfig
++++ b/security/apparmor/Kconfig
+@@ -14,22 +14,6 @@ config SECURITY_APPARMOR
+ 
+ 	  If you are unsure how to answer this question, answer N.
+ 
+-config SECURITY_APPARMOR_BOOTPARAM_VALUE
+-	int "AppArmor boot parameter default value"
+-	depends on SECURITY_APPARMOR
+-	range 0 1
+-	default 1
+-	help
+-	  This option sets the default value for the kernel parameter
+-	  'apparmor', which allows AppArmor to be enabled or disabled
+-          at boot.  If this option is set to 0 (zero), the AppArmor
+-	  kernel parameter will default to 0, disabling AppArmor at
+-	  boot.  If this option is set to 1 (one), the AppArmor
+-	  kernel parameter will default to 1, enabling AppArmor at
+-	  boot.
+-
+-	  If you are unsure how to answer this question, answer 1.
+-
+ config SECURITY_APPARMOR_HASH
+ 	bool "Enable introspection of sha1 hashes for loaded profiles"
+ 	depends on SECURITY_APPARMOR
+diff --git a/security/apparmor/apparmorfs.c b/security/apparmor/apparmorfs.c
+index 0a57d105cc5b..1d3b33cff786 100644
+--- a/security/apparmor/apparmorfs.c
++++ b/security/apparmor/apparmorfs.c
+@@ -123,22 +123,17 @@ static int aafs_show_path(struct seq_file *seq, struct dentry *dentry)
+ 	return 0;
+ }
+ 
+-static void aafs_i_callback(struct rcu_head *head)
++static void aafs_evict_inode(struct inode *inode)
+ {
+-	struct inode *inode = container_of(head, struct inode, i_rcu);
++	truncate_inode_pages_final(&inode->i_data);
++	clear_inode(inode);
+ 	if (S_ISLNK(inode->i_mode))
+ 		kfree(inode->i_link);
+-	free_inode_nonrcu(inode);
+-}
+-
+-static void aafs_destroy_inode(struct inode *inode)
+-{
+-	call_rcu(&inode->i_rcu, aafs_i_callback);
+ }
+ 
+ static const struct super_operations aafs_super_ops = {
+ 	.statfs = simple_statfs,
+-	.destroy_inode = aafs_destroy_inode,
++	.evict_inode = aafs_evict_inode,
+ 	.show_path = aafs_show_path,
+ };
+ 
+@@ -1748,7 +1743,7 @@ static int ns_rmdir_op(struct inode *dir, struct dentry *dentry)
+ 	if (error)
+ 		return error;
+ 
+-	 parent = aa_get_ns(dir->i_private);
++	parent = aa_get_ns(dir->i_private);
+ 	/* rmdir calls the generic securityfs functions to remove files
+ 	 * from the apparmor dir. It is up to the apparmor ns locking
+ 	 * to avoid races.
+diff --git a/security/apparmor/audit.c b/security/apparmor/audit.c
+index eeaddfe0c0fb..9a726892a068 100644
+--- a/security/apparmor/audit.c
++++ b/security/apparmor/audit.c
+@@ -225,14 +225,14 @@ int aa_audit_rule_known(struct audit_krule *rule)
+ 	return 0;
+ }
+ 
+-int aa_audit_rule_match(u32 sid, u32 field, u32 op, void *vrule,
++int aa_audit_rule_match(struct lsm_export *l, u32 field, u32 op, void *vrule,
+ 			struct audit_context *actx)
+ {
+ 	struct aa_audit_rule *rule = vrule;
+ 	struct aa_label *label;
+ 	int found = 0;
+ 
+-	label = aa_secid_to_label(sid);
++	label = aa_secid_to_label(l);
+ 
+ 	if (!label)
+ 		return -ENOENT;
+diff --git a/security/apparmor/capability.c b/security/apparmor/capability.c
+index 752f73980e30..253ef6e9d445 100644
+--- a/security/apparmor/capability.c
++++ b/security/apparmor/capability.c
+@@ -110,13 +110,13 @@ static int audit_caps(struct common_audit_data *sa, struct aa_profile *profile,
+  * profile_capable - test if profile allows use of capability @cap
+  * @profile: profile being enforced    (NOT NULL, NOT unconfined)
+  * @cap: capability to test if allowed
+- * @opts: CAP_OPT_NOAUDIT bit determines whether audit record is generated
++ * @audit: whether an audit record should be generated
+  * @sa: audit data (MAY BE NULL indicating no auditing)
+  *
+  * Returns: 0 if allowed else -EPERM
+  */
+-static int profile_capable(struct aa_profile *profile, int cap,
+-			   unsigned int opts, struct common_audit_data *sa)
++static int profile_capable(struct aa_profile *profile, int cap, int audit,
++			   struct common_audit_data *sa)
+ {
+ 	int error;
+ 
+@@ -126,7 +126,7 @@ static int profile_capable(struct aa_profile *profile, int cap,
+ 	else
+ 		error = -EPERM;
+ 
+-	if (opts & CAP_OPT_NOAUDIT) {
++	if (audit == SECURITY_CAP_NOAUDIT) {
+ 		if (!COMPLAIN_MODE(profile))
+ 			return error;
+ 		/* audit the cap request in complain mode but note that it
+@@ -142,13 +142,13 @@ static int profile_capable(struct aa_profile *profile, int cap,
+  * aa_capable - test permission to use capability
+  * @label: label being tested for capability (NOT NULL)
+  * @cap: capability to be tested
+- * @opts: CAP_OPT_NOAUDIT bit determines whether audit record is generated
++ * @audit: whether an audit record should be generated
+  *
+  * Look up capability in profile capability set.
+  *
+  * Returns: 0 on success, or else an error code.
+  */
+-int aa_capable(struct aa_label *label, int cap, unsigned int opts)
++int aa_capable(struct aa_label *label, int cap, int audit)
+ {
+ 	struct aa_profile *profile;
+ 	int error = 0;
+@@ -156,7 +156,7 @@ int aa_capable(struct aa_label *label, int cap, unsigned int opts)
+ 
+ 	sa.u.cap = cap;
+ 	error = fn_for_each_confined(label, profile,
+-			profile_capable(profile, cap, opts, &sa));
++			profile_capable(profile, cap, audit, &sa));
+ 
+ 	return error;
+ }
+diff --git a/security/apparmor/domain.c b/security/apparmor/domain.c
+index bdf9e4cefe25..d949c7dc8f50 100644
+--- a/security/apparmor/domain.c
++++ b/security/apparmor/domain.c
+@@ -979,7 +979,7 @@ int apparmor_bprm_set_creds(struct linux_binprm *bprm)
+ 	}
+ 	aa_put_label(cred_label(bprm->cred));
+ 	/* transfer reference, released when cred is freed */
+-	cred_label(bprm->cred) = new;
++	set_cred_label(bprm->cred, new);
+ 
+ done:
+ 	aa_put_label(label);
+@@ -1448,10 +1448,7 @@ int aa_change_profile(const char *fqname, int flags)
+ 			new = aa_label_merge(label, target, GFP_KERNEL);
+ 		if (IS_ERR_OR_NULL(new)) {
+ 			info = "failed to build target label";
+-			if (!new)
+-				error = -ENOMEM;
+-			else
+-				error = PTR_ERR(new);
++			error = PTR_ERR(new);
+ 			new = NULL;
+ 			perms.allow = 0;
+ 			goto audit;
+diff --git a/security/apparmor/file.c b/security/apparmor/file.c
+index 4285943f7260..d0afed9ebd0e 100644
+--- a/security/apparmor/file.c
++++ b/security/apparmor/file.c
+@@ -496,7 +496,7 @@ static void update_file_ctx(struct aa_file_ctx *fctx, struct aa_label *label,
+ 	/* update caching of label on file_ctx */
+ 	spin_lock(&fctx->lock);
+ 	old = rcu_dereference_protected(fctx->label,
+-					spin_is_locked(&fctx->lock));
++					lockdep_is_held(&fctx->lock));
+ 	l = aa_label_merge(old, label, GFP_ATOMIC);
+ 	if (l) {
+ 		if (l != old) {
+diff --git a/security/apparmor/include/audit.h b/security/apparmor/include/audit.h
+index b8c8b1066b0a..5e4632bacd32 100644
+--- a/security/apparmor/include/audit.h
++++ b/security/apparmor/include/audit.h
+@@ -192,7 +192,7 @@ static inline int complain_error(int error)
+ void aa_audit_rule_free(void *vrule);
+ int aa_audit_rule_init(u32 field, u32 op, char *rulestr, void **vrule);
+ int aa_audit_rule_known(struct audit_krule *rule);
+-int aa_audit_rule_match(u32 sid, u32 field, u32 op, void *vrule,
++int aa_audit_rule_match(struct lsm_export *l, u32 field, u32 op, void *vrule,
+ 			struct audit_context *actx);
+ 
+ #endif /* __AA_AUDIT_H */
+diff --git a/security/apparmor/include/capability.h b/security/apparmor/include/capability.h
+index 1b3663b6ab12..e0304e2aeb7f 100644
+--- a/security/apparmor/include/capability.h
++++ b/security/apparmor/include/capability.h
+@@ -40,7 +40,7 @@ struct aa_caps {
+ 
+ extern struct aa_sfs_entry aa_sfs_entry_caps[];
+ 
+-int aa_capable(struct aa_label *label, int cap, unsigned int opts);
++int aa_capable(struct aa_label *label, int cap, int audit);
+ 
+ static inline void aa_free_cap_rules(struct aa_caps *caps)
+ {
+diff --git a/security/apparmor/include/cred.h b/security/apparmor/include/cred.h
+index 265ae6641a06..b9504a05fddc 100644
+--- a/security/apparmor/include/cred.h
++++ b/security/apparmor/include/cred.h
+@@ -23,8 +23,22 @@
+ #include "policy_ns.h"
+ #include "task.h"
+ 
+-#define cred_label(X) ((X)->security)
++static inline struct aa_label *cred_label(const struct cred *cred)
++{
++	struct aa_label **blob = cred->security + apparmor_blob_sizes.lbs_cred;
++
++	AA_BUG(!blob);
++	return *blob;
++}
+ 
++static inline void set_cred_label(const struct cred *cred,
++				  struct aa_label *label)
++{
++	struct aa_label **blob = cred->security + apparmor_blob_sizes.lbs_cred;
++
++	AA_BUG(!blob);
++	*blob = label;
++}
+ 
+ /**
+  * aa_cred_raw_label - obtain cred's label
+diff --git a/security/apparmor/include/file.h b/security/apparmor/include/file.h
+index 4c2c8ac8842f..8be09208cf7c 100644
+--- a/security/apparmor/include/file.h
++++ b/security/apparmor/include/file.h
+@@ -32,7 +32,10 @@ struct path;
+ 				 AA_MAY_CHMOD | AA_MAY_CHOWN | AA_MAY_LOCK | \
+ 				 AA_EXEC_MMAP | AA_MAY_LINK)
+ 
+-#define file_ctx(X) ((struct aa_file_ctx *)(X)->f_security)
++static inline struct aa_file_ctx *file_ctx(struct file *file)
++{
++	return file->f_security + apparmor_blob_sizes.lbs_file;
++}
+ 
+ /* struct aa_file_ctx - the AppArmor context the file was opened in
+  * @lock: lock to update the ctx
+diff --git a/security/apparmor/include/lib.h b/security/apparmor/include/lib.h
+index 6505e1ad9e23..bbe9b384d71d 100644
+--- a/security/apparmor/include/lib.h
++++ b/security/apparmor/include/lib.h
+@@ -16,6 +16,7 @@
+ 
+ #include <linux/slab.h>
+ #include <linux/fs.h>
++#include <linux/lsm_hooks.h>
+ 
+ #include "match.h"
+ 
+@@ -55,6 +56,9 @@ const char *aa_splitn_fqname(const char *fqname, size_t n, const char **ns_name,
+ 			     size_t *ns_len);
+ void aa_info_message(const char *str);
+ 
++/* Security blob offsets */
++extern struct lsm_blob_sizes apparmor_blob_sizes;
++
+ /**
+  * aa_strneq - compare null terminated @str to a non null terminated substring
+  * @str: a null terminated string
+diff --git a/security/apparmor/include/net.h b/security/apparmor/include/net.h
+index ec7228e857a9..adac04e3b3cc 100644
+--- a/security/apparmor/include/net.h
++++ b/security/apparmor/include/net.h
+@@ -55,7 +55,11 @@ struct aa_sk_ctx {
+ 	struct aa_label *peer;
+ };
+ 
+-#define SK_CTX(X) ((X)->sk_security)
++static inline struct aa_sk_ctx *aa_sock(const struct sock *sk)
++{
++	return sk->sk_security + apparmor_blob_sizes.lbs_sock;
++}
++
+ #define SOCK_ctx(X) SOCK_INODE(X)->i_security
+ #define DEFINE_AUDIT_NET(NAME, OP, SK, F, T, P)				  \
+ 	struct lsm_network_audit NAME ## _net = { .sk = (SK),		  \
+@@ -83,6 +87,13 @@ struct aa_sk_ctx {
+ 	__e;					\
+ })
+ 
++struct aa_secmark {
++	u8 audit;
++	u8 deny;
++	u32 secid;
++	char *label;
++};
++
+ extern struct aa_sfs_entry aa_sfs_entry_network[];
+ 
+ void audit_net_cb(struct audit_buffer *ab, void *va);
+@@ -103,4 +114,7 @@ int aa_sk_perm(const char *op, u32 request, struct sock *sk);
+ int aa_sock_file_perm(struct aa_label *label, const char *op, u32 request,
+ 		      struct socket *sock);
+ 
++int apparmor_secmark_check(struct aa_label *label, char *op, u32 request,
++			   u32 secid, struct sock *sk);
++
+ #endif /* __AA_NET_H */
+diff --git a/security/apparmor/include/policy.h b/security/apparmor/include/policy.h
+index 28c098fb6208..8e6707c837be 100644
+--- a/security/apparmor/include/policy.h
++++ b/security/apparmor/include/policy.h
+@@ -155,6 +155,9 @@ struct aa_profile {
+ 
+ 	struct aa_rlimit rlimits;
+ 
++	int secmark_count;
++	struct aa_secmark *secmark;
++
+ 	struct aa_loaddata *rawdata;
+ 	unsigned char *hash;
+ 	char *dirname;
+@@ -214,16 +217,7 @@ static inline struct aa_profile *aa_get_newest_profile(struct aa_profile *p)
+ 	return labels_profile(aa_get_newest_label(&p->label));
+ }
+ 
+-static inline unsigned int PROFILE_MEDIATES(struct aa_profile *profile,
+-					    unsigned char class)
+-{
+-	if (class <= AA_CLASS_LAST)
+-		return profile->policy.start[class];
+-	else
+-		return aa_dfa_match_len(profile->policy.dfa,
+-					profile->policy.start[0], &class, 1);
+-}
+-
++#define PROFILE_MEDIATES(P, T)  ((P)->policy.start[(unsigned char) (T)])
+ static inline unsigned int PROFILE_MEDIATES_AF(struct aa_profile *profile,
+ 					       u16 AF) {
+ 	unsigned int state = PROFILE_MEDIATES(profile, AA_CLASS_NET);
+diff --git a/security/apparmor/include/secid.h b/security/apparmor/include/secid.h
+index dee6fa3b6081..a780e56d4f5b 100644
+--- a/security/apparmor/include/secid.h
++++ b/security/apparmor/include/secid.h
+@@ -22,10 +22,14 @@ struct aa_label;
+ /* secid value that will not be allocated */
+ #define AA_SECID_INVALID 0
+ 
+-struct aa_label *aa_secid_to_label(u32 secid);
+-int apparmor_secid_to_secctx(u32 secid, char **secdata, u32 *seclen);
+-int apparmor_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid);
+-void apparmor_release_secctx(char *secdata, u32 seclen);
++/* secid value that matches any other secid */
++#define AA_SECID_WILDCARD 1
++
++struct aa_label *aa_secid_to_label(struct lsm_export *l);
++int apparmor_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp);
++int apparmor_secctx_to_secid(const struct lsm_context *cp,
++			     struct lsm_export *l);
++void apparmor_release_secctx(struct lsm_context *cp);
+ 
+ 
+ int aa_alloc_secid(struct aa_label *label, gfp_t gfp);
+diff --git a/security/apparmor/include/task.h b/security/apparmor/include/task.h
+index 55edaa1d83f8..311e652324e3 100644
+--- a/security/apparmor/include/task.h
++++ b/security/apparmor/include/task.h
+@@ -14,7 +14,10 @@
+ #ifndef __AA_TASK_H
+ #define __AA_TASK_H
+ 
+-#define task_ctx(X) ((X)->security)
++static inline struct aa_task_ctx *task_ctx(struct task_struct *task)
++{
++	return task->security + apparmor_blob_sizes.lbs_task;
++}
+ 
+ /*
+  * struct aa_task_ctx - information for current task label change
+@@ -36,17 +39,6 @@ int aa_set_current_hat(struct aa_label *label, u64 token);
+ int aa_restore_previous_label(u64 cookie);
+ struct aa_label *aa_get_task_label(struct task_struct *task);
+ 
+-/**
+- * aa_alloc_task_ctx - allocate a new task_ctx
+- * @flags: gfp flags for allocation
+- *
+- * Returns: allocated buffer or NULL on failure
+- */
+-static inline struct aa_task_ctx *aa_alloc_task_ctx(gfp_t flags)
+-{
+-	return kzalloc(sizeof(struct aa_task_ctx), flags);
+-}
+-
+ /**
+  * aa_free_task_ctx - free a task_ctx
+  * @ctx: task_ctx to free (MAYBE NULL)
+@@ -57,8 +49,6 @@ static inline void aa_free_task_ctx(struct aa_task_ctx *ctx)
+ 		aa_put_label(ctx->nnp);
+ 		aa_put_label(ctx->previous);
+ 		aa_put_label(ctx->onexec);
+-
+-		kzfree(ctx);
+ 	}
+ }
+ 
+diff --git a/security/apparmor/ipc.c b/security/apparmor/ipc.c
+index aacd1e95cb59..527ea1557120 100644
+--- a/security/apparmor/ipc.c
++++ b/security/apparmor/ipc.c
+@@ -107,8 +107,7 @@ static int profile_tracer_perm(struct aa_profile *tracer,
+ 	aad(sa)->label = &tracer->label;
+ 	aad(sa)->peer = tracee;
+ 	aad(sa)->request = 0;
+-	aad(sa)->error = aa_capable(&tracer->label, CAP_SYS_PTRACE,
+-				    CAP_OPT_NONE);
++	aad(sa)->error = aa_capable(&tracer->label, CAP_SYS_PTRACE, 1);
+ 
+ 	return aa_audit(AUDIT_APPARMOR_AUTO, tracer, sa, audit_ptrace_cb);
+ }
+diff --git a/security/apparmor/lsm.c b/security/apparmor/lsm.c
+index 730de4638b4e..43e89629b5d7 100644
+--- a/security/apparmor/lsm.c
++++ b/security/apparmor/lsm.c
+@@ -23,6 +23,8 @@
+ #include <linux/sysctl.h>
+ #include <linux/audit.h>
+ #include <linux/user_namespace.h>
++#include <linux/netfilter_ipv4.h>
++#include <linux/netfilter_ipv6.h>
+ #include <net/sock.h>
+ 
+ #include "include/apparmor.h"
+@@ -46,6 +48,14 @@ int apparmor_initialized;
+ 
+ DEFINE_PER_CPU(struct aa_buffers, aa_buffers);
+ 
++/*
++ * Set the AppArmor secid in an lsm_export structure
++ */
++static inline void apparmor_export_secid(struct lsm_export *l, u32 secid)
++{
++	l->apparmor = secid;
++	l->flags |= LSM_EXPORT_APPARMOR;
++}
+ 
+ /*
+  * LSM hook functions
+@@ -57,7 +67,7 @@ DEFINE_PER_CPU(struct aa_buffers, aa_buffers);
+ static void apparmor_cred_free(struct cred *cred)
+ {
+ 	aa_put_label(cred_label(cred));
+-	cred_label(cred) = NULL;
++	set_cred_label(cred, NULL);
+ }
+ 
+ /*
+@@ -65,7 +75,7 @@ static void apparmor_cred_free(struct cred *cred)
+  */
+ static int apparmor_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+ {
+-	cred_label(cred) = NULL;
++	set_cred_label(cred, NULL);
+ 	return 0;
+ }
+ 
+@@ -75,7 +85,7 @@ static int apparmor_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+ static int apparmor_cred_prepare(struct cred *new, const struct cred *old,
+ 				 gfp_t gfp)
+ {
+-	cred_label(new) = aa_get_newest_label(cred_label(old));
++	set_cred_label(new, aa_get_newest_label(cred_label(old)));
+ 	return 0;
+ }
+ 
+@@ -84,26 +94,21 @@ static int apparmor_cred_prepare(struct cred *new, const struct cred *old,
+  */
+ static void apparmor_cred_transfer(struct cred *new, const struct cred *old)
+ {
+-	cred_label(new) = aa_get_newest_label(cred_label(old));
++	set_cred_label(new, aa_get_newest_label(cred_label(old)));
+ }
+ 
+ static void apparmor_task_free(struct task_struct *task)
+ {
+ 
+ 	aa_free_task_ctx(task_ctx(task));
+-	task_ctx(task) = NULL;
+ }
+ 
+ static int apparmor_task_alloc(struct task_struct *task,
+ 			       unsigned long clone_flags)
+ {
+-	struct aa_task_ctx *new = aa_alloc_task_ctx(GFP_KERNEL);
+-
+-	if (!new)
+-		return -ENOMEM;
++	struct aa_task_ctx *new = task_ctx(task);
+ 
+ 	aa_dup_task_ctx(new, task_ctx(current));
+-	task_ctx(task) = new;
+ 
+ 	return 0;
+ }
+@@ -130,11 +135,11 @@ static int apparmor_ptrace_traceme(struct task_struct *parent)
+ 	struct aa_label *tracer, *tracee;
+ 	int error;
+ 
+-	tracee = begin_current_label_crit_section();
++	tracee = __begin_current_label_crit_section();
+ 	tracer = aa_get_task_label(parent);
+ 	error = aa_may_ptrace(tracer, tracee, AA_PTRACE_TRACE);
+ 	aa_put_label(tracer);
+-	end_current_label_crit_section(tracee);
++	__end_current_label_crit_section(tracee);
+ 
+ 	return error;
+ }
+@@ -174,14 +179,14 @@ static int apparmor_capget(struct task_struct *target, kernel_cap_t *effective,
+ }
+ 
+ static int apparmor_capable(const struct cred *cred, struct user_namespace *ns,
+-			    int cap, unsigned int opts)
++			    int cap, int audit)
+ {
+ 	struct aa_label *label;
+ 	int error = 0;
+ 
+ 	label = aa_get_newest_cred_label(cred);
+ 	if (!unconfined(label))
+-		error = aa_capable(label, cap, opts);
++		error = aa_capable(label, cap, audit);
+ 	aa_put_label(label);
+ 
+ 	return error;
+@@ -431,21 +436,21 @@ static int apparmor_file_open(struct file *file)
+ 
+ static int apparmor_file_alloc_security(struct file *file)
+ {
+-	int error = 0;
+-
+-	/* freed by apparmor_file_free_security */
++	struct aa_file_ctx *ctx = file_ctx(file);
+ 	struct aa_label *label = begin_current_label_crit_section();
+-	file->f_security = aa_alloc_file_ctx(label, GFP_KERNEL);
+-	if (!file_ctx(file))
+-		error = -ENOMEM;
+-	end_current_label_crit_section(label);
+ 
+-	return error;
++	spin_lock_init(&ctx->lock);
++	rcu_assign_pointer(ctx->label, aa_get_label(label));
++	end_current_label_crit_section(label);
++	return 0;
+ }
+ 
+ static void apparmor_file_free_security(struct file *file)
+ {
+-	aa_free_file_ctx(file_ctx(file));
++	struct aa_file_ctx *ctx = file_ctx(file);
++
++	if (ctx)
++		aa_put_label(rcu_access_pointer(ctx->label));
+ }
+ 
+ static int common_file_perm(const char *op, struct file *file, u32 mask)
+@@ -712,10 +717,10 @@ static void apparmor_bprm_committed_creds(struct linux_binprm *bprm)
+ 	return;
+ }
+ 
+-static void apparmor_task_getsecid(struct task_struct *p, u32 *secid)
++static void apparmor_task_getsecid(struct task_struct *p, struct lsm_export *l)
+ {
+ 	struct aa_label *label = aa_get_task_label(p);
+-	*secid = label->secid;
++	apparmor_export_secid(l, label->secid);
+ 	aa_put_label(label);
+ }
+ 
+@@ -759,33 +764,15 @@ static int apparmor_task_kill(struct task_struct *target, struct siginfo *info,
+ 	return error;
+ }
+ 
+-/**
+- * apparmor_sk_alloc_security - allocate and attach the sk_security field
+- */
+-static int apparmor_sk_alloc_security(struct sock *sk, int family, gfp_t flags)
+-{
+-	struct aa_sk_ctx *ctx;
+-
+-	ctx = kzalloc(sizeof(*ctx), flags);
+-	if (!ctx)
+-		return -ENOMEM;
+-
+-	SK_CTX(sk) = ctx;
+-
+-	return 0;
+-}
+-
+ /**
+  * apparmor_sk_free_security - free the sk_security field
+  */
+ static void apparmor_sk_free_security(struct sock *sk)
+ {
+-	struct aa_sk_ctx *ctx = SK_CTX(sk);
++	struct aa_sk_ctx *ctx = aa_sock(sk);
+ 
+-	SK_CTX(sk) = NULL;
+ 	aa_put_label(ctx->label);
+ 	aa_put_label(ctx->peer);
+-	kfree(ctx);
+ }
+ 
+ /**
+@@ -794,8 +781,8 @@ static void apparmor_sk_free_security(struct sock *sk)
+ static void apparmor_sk_clone_security(const struct sock *sk,
+ 				       struct sock *newsk)
+ {
+-	struct aa_sk_ctx *ctx = SK_CTX(sk);
+-	struct aa_sk_ctx *new = SK_CTX(newsk);
++	struct aa_sk_ctx *ctx = aa_sock(sk);
++	struct aa_sk_ctx *new = aa_sock(newsk);
+ 
+ 	new->label = aa_get_label(ctx->label);
+ 	new->peer = aa_get_label(ctx->peer);
+@@ -846,7 +833,7 @@ static int apparmor_socket_post_create(struct socket *sock, int family,
+ 		label = aa_get_current_label();
+ 
+ 	if (sock->sk) {
+-		struct aa_sk_ctx *ctx = SK_CTX(sock->sk);
++		struct aa_sk_ctx *ctx = aa_sock(sock->sk);
+ 
+ 		aa_put_label(ctx->label);
+ 		ctx->label = aa_get_label(label);
+@@ -1020,6 +1007,7 @@ static int apparmor_socket_shutdown(struct socket *sock, int how)
+ 	return aa_sock_perm(OP_SHUTDOWN, AA_MAY_SHUTDOWN, sock);
+ }
+ 
++#ifdef CONFIG_NETWORK_SECMARK
+ /**
+  * apparmor_socket_sock_recv_skb - check perms before associating skb to sk
+  *
+@@ -1030,13 +1018,20 @@ static int apparmor_socket_shutdown(struct socket *sock, int how)
+  */
+ static int apparmor_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ {
+-	return 0;
++	struct aa_sk_ctx *ctx = aa_sock(sk);
++
++	if (!skb->secmark)
++		return 0;
++
++	return apparmor_secmark_check(ctx->label, OP_RECVMSG, AA_MAY_RECEIVE,
++				      skb->secmark, sk);
+ }
++#endif
+ 
+ 
+ static struct aa_label *sk_peer_label(struct sock *sk)
+ {
+-	struct aa_sk_ctx *ctx = SK_CTX(sk);
++	struct aa_sk_ctx *ctx = aa_sock(sk);
+ 
+ 	if (ctx->peer)
+ 		return ctx->peer;
+@@ -1098,14 +1093,9 @@ static int apparmor_socket_getpeersec_stream(struct socket *sock,
+  * @secid: pointer to where to put the secid of the packet
+  *
+  * Sets the netlabel socket state on sk from parent
++ *
++ * The TODO stub interfered with stacking and was removed - Casey
+  */
+-static int apparmor_socket_getpeersec_dgram(struct socket *sock,
+-					    struct sk_buff *skb, u32 *secid)
+-
+-{
+-	/* TODO: requires secid support */
+-	return -ENOPROTOOPT;
+-}
+ 
+ /**
+  * apparmor_sock_graft - Initialize newly created socket
+@@ -1120,12 +1110,36 @@ static int apparmor_socket_getpeersec_dgram(struct socket *sock,
+  */
+ static void apparmor_sock_graft(struct sock *sk, struct socket *parent)
+ {
+-	struct aa_sk_ctx *ctx = SK_CTX(sk);
++	struct aa_sk_ctx *ctx = aa_sock(sk);
+ 
+ 	if (!ctx->label)
+ 		ctx->label = aa_get_current_label();
+ }
+ 
++#ifdef CONFIG_NETWORK_SECMARK
++static int apparmor_inet_conn_request(struct sock *sk, struct sk_buff *skb,
++				      struct request_sock *req)
++{
++	struct aa_sk_ctx *ctx = aa_sock(sk);
++
++	if (!skb->secmark)
++		return 0;
++
++	return apparmor_secmark_check(ctx->label, OP_CONNECT, AA_MAY_CONNECT,
++				      skb->secmark, sk);
++}
++#endif
++
++/*
++ * The cred blob is a pointer to, not an instance of, an aa_task_ctx.
++ */
++struct lsm_blob_sizes apparmor_blob_sizes __lsm_ro_after_init = {
++	.lbs_cred = sizeof(struct aa_task_ctx *),
++	.lbs_file = sizeof(struct aa_file_ctx),
++	.lbs_task = sizeof(struct aa_task_ctx),
++	.lbs_sock = sizeof(struct aa_sk_ctx),
++};
++
+ static struct security_hook_list apparmor_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(ptrace_access_check, apparmor_ptrace_access_check),
+ 	LSM_HOOK_INIT(ptrace_traceme, apparmor_ptrace_traceme),
+@@ -1160,7 +1174,6 @@ static struct security_hook_list apparmor_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(getprocattr, apparmor_getprocattr),
+ 	LSM_HOOK_INIT(setprocattr, apparmor_setprocattr),
+ 
+-	LSM_HOOK_INIT(sk_alloc_security, apparmor_sk_alloc_security),
+ 	LSM_HOOK_INIT(sk_free_security, apparmor_sk_free_security),
+ 	LSM_HOOK_INIT(sk_clone_security, apparmor_sk_clone_security),
+ 
+@@ -1177,12 +1190,15 @@ static struct security_hook_list apparmor_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(socket_getsockopt, apparmor_socket_getsockopt),
+ 	LSM_HOOK_INIT(socket_setsockopt, apparmor_socket_setsockopt),
+ 	LSM_HOOK_INIT(socket_shutdown, apparmor_socket_shutdown),
++#ifdef CONFIG_NETWORK_SECMARK
+ 	LSM_HOOK_INIT(socket_sock_rcv_skb, apparmor_socket_sock_rcv_skb),
++#endif
+ 	LSM_HOOK_INIT(socket_getpeersec_stream,
+ 		      apparmor_socket_getpeersec_stream),
+-	LSM_HOOK_INIT(socket_getpeersec_dgram,
+-		      apparmor_socket_getpeersec_dgram),
+ 	LSM_HOOK_INIT(sock_graft, apparmor_sock_graft),
++#ifdef CONFIG_NETWORK_SECMARK
++	LSM_HOOK_INIT(inet_conn_request, apparmor_inet_conn_request),
++#endif
+ 
+ 	LSM_HOOK_INIT(cred_alloc_blank, apparmor_cred_alloc_blank),
+ 	LSM_HOOK_INIT(cred_free, apparmor_cred_free),
+@@ -1208,7 +1224,6 @@ static struct security_hook_list apparmor_hooks[] __lsm_ro_after_init = {
+ 
+ 	LSM_HOOK_INIT(secid_to_secctx, apparmor_secid_to_secctx),
+ 	LSM_HOOK_INIT(secctx_to_secid, apparmor_secctx_to_secid),
+-	LSM_HOOK_INIT(release_secctx, apparmor_release_secctx),
+ };
+ 
+ /*
+@@ -1303,8 +1318,8 @@ bool aa_g_paranoid_load = true;
+ module_param_named(paranoid_load, aa_g_paranoid_load, aabool, S_IRUGO);
+ 
+ /* Boot time disable flag */
+-static bool apparmor_enabled = CONFIG_SECURITY_APPARMOR_BOOTPARAM_VALUE;
+-module_param_named(enabled, apparmor_enabled, bool, S_IRUGO);
++static int apparmor_enabled __lsm_ro_after_init = 1;
++module_param_named(enabled, apparmor_enabled, int, 0444);
+ 
+ static int __init apparmor_enabled_setup(char *str)
+ {
+@@ -1449,14 +1464,10 @@ static int param_set_mode(const char *val, const struct kernel_param *kp)
+ static int __init set_init_ctx(void)
+ {
+ 	struct cred *cred = (struct cred *)current->real_cred;
+-	struct aa_task_ctx *ctx;
+-
+-	ctx = aa_alloc_task_ctx(GFP_KERNEL);
+-	if (!ctx)
+-		return -ENOMEM;
+ 
+-	cred_label(cred) = aa_get_label(ns_unconfined(root_ns));
+-	task_ctx(current) = ctx;
++	lsm_early_cred(cred);
++	lsm_early_task(current);
++	set_cred_label(cred, aa_get_label(ns_unconfined(root_ns)));
+ 
+ 	return 0;
+ }
+@@ -1538,15 +1549,100 @@ static inline int apparmor_init_sysctl(void)
+ }
+ #endif /* CONFIG_SYSCTL */
+ 
+-static int __init apparmor_init(void)
++#if defined(CONFIG_NETFILTER) && defined(CONFIG_NETWORK_SECMARK)
++static unsigned int apparmor_ip_postroute(void *priv,
++					  struct sk_buff *skb,
++					  const struct nf_hook_state *state)
+ {
+-	int error;
++	struct aa_sk_ctx *ctx;
++	struct sock *sk;
++
++	if (!skb->secmark)
++		return NF_ACCEPT;
++
++	sk = skb_to_full_sk(skb);
++	if (sk == NULL)
++		return NF_ACCEPT;
++
++	ctx = aa_sock(sk);
++	if (!apparmor_secmark_check(ctx->label, OP_SENDMSG, AA_MAY_SEND,
++				    skb->secmark, sk))
++		return NF_ACCEPT;
++
++	return NF_DROP_ERR(-ECONNREFUSED);
++
++}
++
++static unsigned int apparmor_ipv4_postroute(void *priv,
++					    struct sk_buff *skb,
++					    const struct nf_hook_state *state)
++{
++	return apparmor_ip_postroute(priv, skb, state);
++}
+ 
+-	if (!apparmor_enabled || !security_module_enable("apparmor")) {
+-		aa_info_message("AppArmor disabled by boot time parameter");
+-		apparmor_enabled = false;
++static unsigned int apparmor_ipv6_postroute(void *priv,
++					    struct sk_buff *skb,
++					    const struct nf_hook_state *state)
++{
++	return apparmor_ip_postroute(priv, skb, state);
++}
++
++static const struct nf_hook_ops apparmor_nf_ops[] = {
++	{
++		.hook =         apparmor_ipv4_postroute,
++		.pf =           NFPROTO_IPV4,
++		.hooknum =      NF_INET_POST_ROUTING,
++		.priority =     NF_IP_PRI_SELINUX_FIRST,
++	},
++#if IS_ENABLED(CONFIG_IPV6)
++	{
++		.hook =         apparmor_ipv6_postroute,
++		.pf =           NFPROTO_IPV6,
++		.hooknum =      NF_INET_POST_ROUTING,
++		.priority =     NF_IP6_PRI_SELINUX_FIRST,
++	},
++#endif
++};
++
++static int __net_init apparmor_nf_register(struct net *net)
++{
++	int ret;
++
++	ret = nf_register_net_hooks(net, apparmor_nf_ops,
++				    ARRAY_SIZE(apparmor_nf_ops));
++	return ret;
++}
++
++static void __net_exit apparmor_nf_unregister(struct net *net)
++{
++	nf_unregister_net_hooks(net, apparmor_nf_ops,
++				ARRAY_SIZE(apparmor_nf_ops));
++}
++
++static struct pernet_operations apparmor_net_ops = {
++	.init = apparmor_nf_register,
++	.exit = apparmor_nf_unregister,
++};
++
++static int __init apparmor_nf_ip_init(void)
++{
++	int err;
++
++	if (!apparmor_enabled)
+ 		return 0;
+-	}
++
++	err = register_pernet_subsys(&apparmor_net_ops);
++	if (err)
++		panic("Apparmor: register_pernet_subsys: error %d\n", err);
++
++	return 0;
++}
++__initcall(apparmor_nf_ip_init);
++#endif
++
++static int __init apparmor_init(void)
++{
++	int error;
+ 
+ 	aa_secids_init();
+ 
+@@ -1606,4 +1702,10 @@ static int __init apparmor_init(void)
+ 	return error;
+ }
+ 
+-security_initcall(apparmor_init);
++DEFINE_LSM(apparmor) = {
++	.name = "apparmor",
++	.flags = LSM_FLAG_LEGACY_MAJOR,
++	.enabled = &apparmor_enabled,
++	.blobs = &apparmor_blob_sizes,
++	.init = apparmor_init,
++};
+diff --git a/security/apparmor/net.c b/security/apparmor/net.c
+index d5d72dd1ca1f..c07fde444792 100644
+--- a/security/apparmor/net.c
++++ b/security/apparmor/net.c
+@@ -18,6 +18,7 @@
+ #include "include/label.h"
+ #include "include/net.h"
+ #include "include/policy.h"
++#include "include/secid.h"
+ 
+ #include "net_names.h"
+ 
+@@ -188,3 +189,70 @@ int aa_sock_file_perm(struct aa_label *label, const char *op, u32 request,
+ 
+ 	return aa_label_sk_perm(label, op, request, sock->sk);
+ }
++
++#ifdef CONFIG_NETWORK_SECMARK
++static int apparmor_secmark_init(struct aa_secmark *secmark)
++{
++	struct aa_label *label;
++
++	if (secmark->label[0] == '*') {
++		secmark->secid = AA_SECID_WILDCARD;
++		return 0;
++	}
++
++	label = aa_label_strn_parse(&root_ns->unconfined->label,
++				    secmark->label, strlen(secmark->label),
++				    GFP_ATOMIC, false, false);
++
++	if (IS_ERR(label))
++		return PTR_ERR(label);
++
++	secmark->secid = label->secid;
++
++	return 0;
++}
++
++static int aa_secmark_perm(struct aa_profile *profile, u32 request, u32 secid,
++			   struct common_audit_data *sa, struct sock *sk)
++{
++	int i, ret;
++	struct aa_perms perms = { };
++
++	if (profile->secmark_count == 0)
++		return 0;
++
++	for (i = 0; i < profile->secmark_count; i++) {
++		if (!profile->secmark[i].secid) {
++			ret = apparmor_secmark_init(&profile->secmark[i]);
++			if (ret)
++				return ret;
++		}
++
++		if (profile->secmark[i].secid == secid ||
++		    profile->secmark[i].secid == AA_SECID_WILDCARD) {
++			if (profile->secmark[i].deny)
++				perms.deny = ALL_PERMS_MASK;
++			else
++				perms.allow = ALL_PERMS_MASK;
++
++			if (profile->secmark[i].audit)
++				perms.audit = ALL_PERMS_MASK;
++		}
++	}
++
++	aa_apply_modes_to_perms(profile, &perms);
++
++	return aa_check_perms(profile, &perms, request, sa, audit_net_cb);
++}
++
++int apparmor_secmark_check(struct aa_label *label, char *op, u32 request,
++			   u32 secid, struct sock *sk)
++{
++	struct aa_profile *profile;
++	DEFINE_AUDIT_SK(sa, op, sk);
++
++	return fn_for_each_confined(label, profile,
++				    aa_secmark_perm(profile, request, secid,
++						    &sa, sk));
++}
++#endif
+diff --git a/security/apparmor/policy.c b/security/apparmor/policy.c
+index 3a4293c46ad5..ab407772b649 100644
+--- a/security/apparmor/policy.c
++++ b/security/apparmor/policy.c
+@@ -231,6 +231,9 @@ void aa_free_profile(struct aa_profile *profile)
+ 	for (i = 0; i < profile->xattr_count; i++)
+ 		kzfree(profile->xattrs[i]);
+ 	kzfree(profile->xattrs);
++	for (i = 0; i < profile->secmark_count; i++)
++		kzfree(profile->secmark[i].label);
++	kzfree(profile->secmark);
+ 	kzfree(profile->dirname);
+ 	aa_put_dfa(profile->xmatch);
+ 	aa_put_dfa(profile->policy.dfa);
+diff --git a/security/apparmor/policy_unpack.c b/security/apparmor/policy_unpack.c
+index 612f737cee83..379682e2a8d5 100644
+--- a/security/apparmor/policy_unpack.c
++++ b/security/apparmor/policy_unpack.c
+@@ -223,21 +223,16 @@ static void *kvmemdup(const void *src, size_t len)
+ static size_t unpack_u16_chunk(struct aa_ext *e, char **chunk)
+ {
+ 	size_t size = 0;
+-	void *pos = e->pos;
+ 
+ 	if (!inbounds(e, sizeof(u16)))
+-		goto fail;
++		return 0;
+ 	size = le16_to_cpu(get_unaligned((__le16 *) e->pos));
+ 	e->pos += sizeof(__le16);
+ 	if (!inbounds(e, size))
+-		goto fail;
++		return 0;
+ 	*chunk = e->pos;
+ 	e->pos += size;
+ 	return size;
+-
+-fail:
+-	e->pos = pos;
+-	return 0;
+ }
+ 
+ /* unpack control byte */
+@@ -281,7 +276,7 @@ static bool unpack_nameX(struct aa_ext *e, enum aa_code code, const char *name)
+ 		char *tag = NULL;
+ 		size_t size = unpack_u16_chunk(e, &tag);
+ 		/* if a name is specified it must match. otherwise skip tag */
+-		if (name && (!size || tag[size-1] != '\0' || strcmp(name, tag)))
++		if (name && (!size || strcmp(name, tag)))
+ 			goto fail;
+ 	} else if (name) {
+ 		/* if a name is specified and there is no name tag fail */
+@@ -297,68 +292,64 @@ static bool unpack_nameX(struct aa_ext *e, enum aa_code code, const char *name)
+ 	return 0;
+ }
+ 
+-static bool unpack_u32(struct aa_ext *e, u32 *data, const char *name)
++static bool unpack_u8(struct aa_ext *e, u8 *data, const char *name)
+ {
+-	void *pos = e->pos;
++	if (unpack_nameX(e, AA_U8, name)) {
++		if (!inbounds(e, sizeof(u8)))
++			return 0;
++		if (data)
++			*data = get_unaligned((u8 *)e->pos);
++		e->pos += sizeof(u8);
++		return 1;
++	}
++	return 0;
++}
+ 
++static bool unpack_u32(struct aa_ext *e, u32 *data, const char *name)
++{
+ 	if (unpack_nameX(e, AA_U32, name)) {
+ 		if (!inbounds(e, sizeof(u32)))
+-			goto fail;
++			return 0;
+ 		if (data)
+ 			*data = le32_to_cpu(get_unaligned((__le32 *) e->pos));
+ 		e->pos += sizeof(u32);
+ 		return 1;
+ 	}
+-
+-fail:
+-	e->pos = pos;
+ 	return 0;
+ }
+ 
+ static bool unpack_u64(struct aa_ext *e, u64 *data, const char *name)
+ {
+-	void *pos = e->pos;
+-
+ 	if (unpack_nameX(e, AA_U64, name)) {
+ 		if (!inbounds(e, sizeof(u64)))
+-			goto fail;
++			return 0;
+ 		if (data)
+ 			*data = le64_to_cpu(get_unaligned((__le64 *) e->pos));
+ 		e->pos += sizeof(u64);
+ 		return 1;
+ 	}
+-
+-fail:
+-	e->pos = pos;
+ 	return 0;
+ }
+ 
+ static size_t unpack_array(struct aa_ext *e, const char *name)
+ {
+-	void *pos = e->pos;
+-
+ 	if (unpack_nameX(e, AA_ARRAY, name)) {
+ 		int size;
+ 		if (!inbounds(e, sizeof(u16)))
+-			goto fail;
++			return 0;
+ 		size = (int)le16_to_cpu(get_unaligned((__le16 *) e->pos));
+ 		e->pos += sizeof(u16);
+ 		return size;
+ 	}
+-
+-fail:
+-	e->pos = pos;
+ 	return 0;
+ }
+ 
+ static size_t unpack_blob(struct aa_ext *e, char **blob, const char *name)
+ {
+-	void *pos = e->pos;
+-
+ 	if (unpack_nameX(e, AA_BLOB, name)) {
+ 		u32 size;
+ 		if (!inbounds(e, sizeof(u32)))
+-			goto fail;
++			return 0;
+ 		size = le32_to_cpu(get_unaligned((__le32 *) e->pos));
+ 		e->pos += sizeof(u32);
+ 		if (inbounds(e, (size_t) size)) {
+@@ -367,9 +358,6 @@ static size_t unpack_blob(struct aa_ext *e, char **blob, const char *name)
+ 			return size;
+ 		}
+ 	}
+-
+-fail:
+-	e->pos = pos;
+ 	return 0;
+ }
+ 
+@@ -386,10 +374,9 @@ static int unpack_str(struct aa_ext *e, const char **string, const char *name)
+ 			if (src_str[size - 1] != 0)
+ 				goto fail;
+ 			*string = src_str;
+-
+-			return size;
+ 		}
+ 	}
++	return size;
+ 
+ fail:
+ 	e->pos = pos;
+@@ -555,6 +542,49 @@ static bool unpack_xattrs(struct aa_ext *e, struct aa_profile *profile)
+ 	return 0;
+ }
+ 
++static bool unpack_secmark(struct aa_ext *e, struct aa_profile *profile)
++{
++	void *pos = e->pos;
++	int i, size;
++
++	if (unpack_nameX(e, AA_STRUCT, "secmark")) {
++		size = unpack_array(e, NULL);
++
++		profile->secmark = kcalloc(size, sizeof(struct aa_secmark),
++					   GFP_KERNEL);
++		if (!profile->secmark)
++			goto fail;
++
++		profile->secmark_count = size;
++
++		for (i = 0; i < size; i++) {
++			if (!unpack_u8(e, &profile->secmark[i].audit, NULL))
++				goto fail;
++			if (!unpack_u8(e, &profile->secmark[i].deny, NULL))
++				goto fail;
++			if (!unpack_strdup(e, &profile->secmark[i].label, NULL))
++				goto fail;
++		}
++		if (!unpack_nameX(e, AA_ARRAYEND, NULL))
++			goto fail;
++		if (!unpack_nameX(e, AA_STRUCTEND, NULL))
++			goto fail;
++	}
++
++	return 1;
++
++fail:
++	if (profile->secmark) {
++		for (i = 0; i < size; i++)
++			kfree(profile->secmark[i].label);
++		kfree(profile->secmark);
++		profile->secmark_count = 0;
++	}
++
++	e->pos = pos;
++	return 0;
++}
++
+ static bool unpack_rlimits(struct aa_ext *e, struct aa_profile *profile)
+ {
+ 	void *pos = e->pos;
+@@ -753,6 +783,11 @@ static struct aa_profile *unpack_profile(struct aa_ext *e, char **ns_name)
+ 		goto fail;
+ 	}
+ 
++	if (!unpack_secmark(e, profile)) {
++		info = "failed to unpack profile secmark rules";
++		goto fail;
++	}
++
+ 	if (unpack_nameX(e, AA_STRUCT, "policydb")) {
+ 		/* generic policy dfa - optional and may be NULL */
+ 		info = "failed to unpack policydb";
+diff --git a/security/apparmor/resource.c b/security/apparmor/resource.c
+index 552ed09cb47e..95fd26d09757 100644
+--- a/security/apparmor/resource.c
++++ b/security/apparmor/resource.c
+@@ -124,7 +124,7 @@ int aa_task_setrlimit(struct aa_label *label, struct task_struct *task,
+ 	 */
+ 
+ 	if (label != peer &&
+-	    aa_capable(label, CAP_SYS_RESOURCE, CAP_OPT_NOAUDIT) != 0)
++	    aa_capable(label, CAP_SYS_RESOURCE, SECURITY_CAP_NOAUDIT) != 0)
+ 		error = fn_for_each(label, profile,
+ 				audit_resource(profile, resource,
+ 					       new_rlim->rlim_max, peer,
+diff --git a/security/apparmor/secid.c b/security/apparmor/secid.c
+index 4ccec1bcf6f5..30fd4ad80948 100644
+--- a/security/apparmor/secid.c
++++ b/security/apparmor/secid.c
+@@ -32,8 +32,7 @@
+  * secids - do not pin labels with a refcount. They rely on the label
+  * properly updating/freeing them
+  */
+-
+-#define AA_FIRST_SECID 1
++#define AA_FIRST_SECID 2
+ 
+ static DEFINE_IDR(aa_secids);
+ static DEFINE_SPINLOCK(secid_lock);
+@@ -62,9 +61,12 @@ void aa_secid_update(u32 secid, struct aa_label *label)
+  *
+  * see label for inverse aa_label_to_secid
+  */
+-struct aa_label *aa_secid_to_label(u32 secid)
++struct aa_label *aa_secid_to_label(struct lsm_export *l)
+ {
+ 	struct aa_label *label;
++	u32 secid;
++
++	secid = (l->flags & LSM_EXPORT_APPARMOR) ? l->apparmor : 0;
+ 
+ 	rcu_read_lock();
+ 	label = idr_find(&aa_secids, secid);
+@@ -73,19 +75,30 @@ struct aa_label *aa_secid_to_label(u32 secid)
+ 	return label;
+ }
+ 
+-int apparmor_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
++static inline void aa_export_secid(struct lsm_export *l, u32 secid)
++{
++	l->flags |= LSM_EXPORT_APPARMOR;
++	l->apparmor = secid;
++}
++
++void apparmor_release_secctx(struct lsm_context *cp)
++{
++	kfree(cp->context);
++}
++
++int apparmor_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp)
+ {
+ 	/* TODO: cache secctx and ref count so we don't have to recreate */
+-	struct aa_label *label = aa_secid_to_label(secid);
++	struct aa_label *label;
+ 	int len;
+ 
+-	AA_BUG(!seclen);
++	label = aa_secid_to_label(l);
+ 
+ 	if (!label)
+ 		return -EINVAL;
+ 
+-	if (secdata)
+-		len = aa_label_asxprint(secdata, root_ns, label,
++	if (!(l->flags & LSM_EXPORT_LENGTH))
++		len = aa_label_asxprint(&cp->context, root_ns, label,
+ 					FLAG_SHOW_MODE | FLAG_VIEW_SUBNS |
+ 					FLAG_HIDDEN_UNCONFINED | FLAG_ABS_ROOT,
+ 					GFP_ATOMIC);
+@@ -96,29 +109,25 @@ int apparmor_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
+ 	if (len < 0)
+ 		return -ENOMEM;
+ 
+-	*seclen = len;
++	cp->len = len;
++	cp->release = apparmor_release_secctx;
+ 
+ 	return 0;
+ }
+ 
+-int apparmor_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
++int apparmor_secctx_to_secid(const struct lsm_context *cp, struct lsm_export *l)
+ {
+ 	struct aa_label *label;
+ 
+-	label = aa_label_strn_parse(&root_ns->unconfined->label, secdata,
+-				    seclen, GFP_KERNEL, false, false);
++	label = aa_label_strn_parse(&root_ns->unconfined->label, cp->context,
++				    cp->len, GFP_KERNEL, false, false);
+ 	if (IS_ERR(label))
+ 		return PTR_ERR(label);
+-	*secid = label->secid;
++	aa_export_secid(l, label->secid);
+ 
+ 	return 0;
+ }
+ 
+-void apparmor_release_secctx(char *secdata, u32 seclen)
+-{
+-	kfree(secdata);
+-}
+-
+ /**
+  * aa_alloc_secid - allocate a new secid for a profile
+  * @label: the label to allocate a secid for
+diff --git a/security/apparmor/task.c b/security/apparmor/task.c
+index c6b78a14da91..4551110f0496 100644
+--- a/security/apparmor/task.c
++++ b/security/apparmor/task.c
+@@ -81,7 +81,7 @@ int aa_replace_current_label(struct aa_label *label)
+ 	 */
+ 	aa_get_label(label);
+ 	aa_put_label(cred_label(new));
+-	cred_label(new) = label;
++	set_cred_label(new, label);
+ 
+ 	commit_creds(new);
+ 	return 0;
+@@ -138,7 +138,7 @@ int aa_set_current_hat(struct aa_label *label, u64 token)
+ 		return -EACCES;
+ 	}
+ 
+-	cred_label(new) = aa_get_newest_label(label);
++	set_cred_label(new, aa_get_newest_label(label));
+ 	/* clear exec on switching context */
+ 	aa_put_label(ctx->onexec);
+ 	ctx->onexec = NULL;
+@@ -172,7 +172,7 @@ int aa_restore_previous_label(u64 token)
+ 		return -ENOMEM;
+ 
+ 	aa_put_label(cred_label(new));
+-	cred_label(new) = aa_get_newest_label(ctx->previous);
++	set_cred_label(new, aa_get_newest_label(ctx->previous));
+ 	AA_BUG(!cred_label(new));
+ 	/* clear exec && prev information when restoring to previous context */
+ 	aa_clear_task_ctx_trans(ctx);
+diff --git a/security/commoncap.c b/security/commoncap.c
+index 3023b4ad38a7..d42bb14270c5 100644
+--- a/security/commoncap.c
++++ b/security/commoncap.c
+@@ -69,7 +69,7 @@ static void warn_setuid_and_fcaps_mixed(const char *fname)
+  * kernel's capable() and has_capability() returns 1 for this case.
+  */
+ int cap_capable(const struct cred *cred, struct user_namespace *targ_ns,
+-		int cap, unsigned int opts)
++		int cap, int opts)
+ {
+ 	struct user_namespace *ns = targ_ns;
+ 
+@@ -223,11 +223,12 @@ int cap_capget(struct task_struct *target, kernel_cap_t *effective,
+  */
+ static inline int cap_inh_is_capped(void)
+ {
++
+ 	/* they are so limited unless the current task has the CAP_SETPCAP
+ 	 * capability
+ 	 */
+ 	if (cap_capable(current_cred(), current_cred()->user_ns,
+-			CAP_SETPCAP, CAP_OPT_NONE) == 0)
++			CAP_SETPCAP, SECURITY_CAP_AUDIT) == 0)
+ 		return 0;
+ 	return 1;
+ }
+@@ -683,9 +684,6 @@ static int get_file_caps(struct linux_binprm *bprm, bool *effective, bool *has_f
+ 	}
+ 
+ 	rc = bprm_caps_from_vfs_caps(&vcaps, bprm, effective, has_fcap);
+-	if (rc == -EINVAL)
+-		printk(KERN_NOTICE "%s: cap_from_disk returned %d for %s\n",
+-		       __func__, rc, bprm->filename);
+ 
+ out:
+ 	if (rc)
+@@ -1211,9 +1209,8 @@ int cap_task_prctl(int option, unsigned long arg2, unsigned long arg3,
+ 		    || ((old->securebits & SECURE_ALL_LOCKS & ~arg2))	/*[2]*/
+ 		    || (arg2 & ~(SECURE_ALL_LOCKS | SECURE_ALL_BITS))	/*[3]*/
+ 		    || (cap_capable(current_cred(),
+-				    current_cred()->user_ns,
+-				    CAP_SETPCAP,
+-				    CAP_OPT_NONE) != 0)			/*[4]*/
++				    current_cred()->user_ns, CAP_SETPCAP,
++				    SECURITY_CAP_AUDIT) != 0)		/*[4]*/
+ 			/*
+ 			 * [1] no changing of bits that are locked
+ 			 * [2] no unlocking of locks
+@@ -1308,10 +1305,9 @@ int cap_vm_enough_memory(struct mm_struct *mm, long pages)
+ {
+ 	int cap_sys_admin = 0;
+ 
+-	if (cap_capable(current_cred(), &init_user_ns,
+-				CAP_SYS_ADMIN, CAP_OPT_NOAUDIT) == 0)
++	if (cap_capable(current_cred(), &init_user_ns, CAP_SYS_ADMIN,
++			SECURITY_CAP_NOAUDIT) == 0)
+ 		cap_sys_admin = 1;
+-
+ 	return cap_sys_admin;
+ }
+ 
+@@ -1330,7 +1326,7 @@ int cap_mmap_addr(unsigned long addr)
+ 
+ 	if (addr < dac_mmap_min_addr) {
+ 		ret = cap_capable(current_cred(), &init_user_ns, CAP_SYS_RAWIO,
+-				  CAP_OPT_NONE);
++				  SECURITY_CAP_AUDIT);
+ 		/* set PF_SUPERPRIV if it turns out we allow the low mmap */
+ 		if (ret == 0)
+ 			current->flags |= PF_SUPERPRIV;
+@@ -1367,10 +1363,17 @@ struct security_hook_list capability_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(vm_enough_memory, cap_vm_enough_memory),
+ };
+ 
+-void __init capability_add_hooks(void)
++static int __init capability_init(void)
+ {
+ 	security_add_hooks(capability_hooks, ARRAY_SIZE(capability_hooks),
+ 				"capability");
++	return 0;
+ }
+ 
++DEFINE_LSM(capability) = {
++	.name = "capability",
++	.order = LSM_ORDER_FIRST,
++	.init = capability_init,
++};
++
+ #endif /* CONFIG_SECURITY */
+diff --git a/security/device_cgroup.c b/security/device_cgroup.c
+index dc28914fa72e..cd97929fac66 100644
+--- a/security/device_cgroup.c
++++ b/security/device_cgroup.c
+@@ -560,7 +560,7 @@ static int propagate_exception(struct dev_cgroup *devcg_root,
+ 		    devcg->behavior == DEVCG_DEFAULT_ALLOW) {
+ 			rc = dev_exception_add(devcg, ex);
+ 			if (rc)
+-				return rc;
++				break;
+ 		} else {
+ 			/*
+ 			 * in the other possible cases:
+diff --git a/security/inode.c b/security/inode.c
+index 0107dc7d3232..8dd9ca8848e4 100644
+--- a/security/inode.c
++++ b/security/inode.c
+@@ -26,22 +26,17 @@
+ static struct vfsmount *mount;
+ static int mount_count;
+ 
+-static void securityfs_i_callback(struct rcu_head *head)
++static void securityfs_evict_inode(struct inode *inode)
+ {
+-	struct inode *inode = container_of(head, struct inode, i_rcu);
++	truncate_inode_pages_final(&inode->i_data);
++	clear_inode(inode);
+ 	if (S_ISLNK(inode->i_mode))
+ 		kfree(inode->i_link);
+-	free_inode_nonrcu(inode);
+-}
+-
+-static void securityfs_destroy_inode(struct inode *inode)
+-{
+-	call_rcu(&inode->i_rcu, securityfs_i_callback);
+ }
+ 
+ static const struct super_operations securityfs_super_operations = {
+ 	.statfs		= simple_statfs,
+-	.destroy_inode	= securityfs_destroy_inode,
++	.evict_inode	= securityfs_evict_inode,
+ };
+ 
+ static int fill_super(struct super_block *sb, void *data, int silent)
+@@ -127,7 +122,7 @@ static struct dentry *securityfs_create_dentry(const char *name, umode_t mode,
+ 	dir = d_inode(parent);
+ 
+ 	inode_lock(dir);
+-	dentry = lookup_one_len2(name, mount, parent, strlen(name));
++	dentry = lookup_one_len(name, parent, strlen(name));
+ 	if (IS_ERR(dentry))
+ 		goto out;
+ 
+diff --git a/security/integrity/digsig.c b/security/integrity/digsig.c
+index 9bb0a7f2863e..5eacba858e4b 100644
+--- a/security/integrity/digsig.c
++++ b/security/integrity/digsig.c
+@@ -26,7 +26,7 @@
+ 
+ static struct key *keyring[INTEGRITY_KEYRING_MAX];
+ 
+-static const char *keyring_name[INTEGRITY_KEYRING_MAX] = {
++static const char * const keyring_name[INTEGRITY_KEYRING_MAX] = {
+ #ifndef CONFIG_INTEGRITY_TRUSTED_KEYRING
+ 	"_evm",
+ 	"_ima",
+@@ -37,12 +37,6 @@ static const char *keyring_name[INTEGRITY_KEYRING_MAX] = {
+ 	"_module",
+ };
+ 
+-#ifdef CONFIG_INTEGRITY_TRUSTED_KEYRING
+-static bool init_keyring __initdata = true;
+-#else
+-static bool init_keyring __initdata;
+-#endif
+-
+ #ifdef CONFIG_IMA_KEYRINGS_PERMIT_SIGNED_BY_BUILTIN_OR_SECONDARY
+ #define restrict_link_to_ima restrict_link_by_builtin_and_secondary_trusted
+ #else
+@@ -85,7 +79,7 @@ int __init integrity_init_keyring(const unsigned int id)
+ 	struct key_restriction *restriction;
+ 	int err = 0;
+ 
+-	if (!init_keyring)
++	if (!IS_ENABLED(CONFIG_INTEGRITY_TRUSTED_KEYRING))
+ 		return 0;
+ 
+ 	restriction = kzalloc(sizeof(struct key_restriction), GFP_KERNEL);
+diff --git a/security/integrity/evm/evm_crypto.c b/security/integrity/evm/evm_crypto.c
+index 6a314fb0d480..8c25f949ebdb 100644
+--- a/security/integrity/evm/evm_crypto.c
++++ b/security/integrity/evm/evm_crypto.c
+@@ -27,7 +27,7 @@
+ #define EVMKEY "evm-key"
+ #define MAX_KEY_SIZE 128
+ static unsigned char evmkey[MAX_KEY_SIZE];
+-static int evmkey_len = MAX_KEY_SIZE;
++static const int evmkey_len = MAX_KEY_SIZE;
+ 
+ struct crypto_shash *hmac_tfm;
+ static struct crypto_shash *evm_tfm[HASH_ALGO__LAST];
+@@ -38,7 +38,7 @@ static DEFINE_MUTEX(mutex);
+ 
+ static unsigned long evm_set_key_flags;
+ 
+-static char * const evm_hmac = "hmac(sha1)";
++static const char evm_hmac[] = "hmac(sha1)";
+ 
+ /**
+  * evm_set_key() - set EVM HMAC key from the kernel
+@@ -89,9 +89,6 @@ static struct shash_desc *init_desc(char type, uint8_t hash_algo)
+ 		tfm = &hmac_tfm;
+ 		algo = evm_hmac;
+ 	} else {
+-		if (hash_algo >= HASH_ALGO__LAST)
+-			return ERR_PTR(-EINVAL);
+-
+ 		tfm = &evm_tfm[hash_algo];
+ 		algo = hash_algo_name[hash_algo];
+ 	}
+diff --git a/security/integrity/iint.c b/security/integrity/iint.c
+index 5a6810041e5c..1ea05da2323d 100644
+--- a/security/integrity/iint.c
++++ b/security/integrity/iint.c
+@@ -22,6 +22,7 @@
+ #include <linux/file.h>
+ #include <linux/uaccess.h>
+ #include <linux/security.h>
++#include <linux/lsm_hooks.h>
+ #include "integrity.h"
+ 
+ static struct rb_root integrity_iint_tree = RB_ROOT;
+@@ -174,7 +175,10 @@ static int __init integrity_iintcache_init(void)
+ 			      0, SLAB_PANIC, init_once);
+ 	return 0;
+ }
+-security_initcall(integrity_iintcache_init);
++DEFINE_LSM(integrity) = {
++	.name = "integrity",
++	.init = integrity_iintcache_init,
++};
+ 
+ 
+ /*
+diff --git a/security/integrity/ima/ima.h b/security/integrity/ima/ima.h
+index 67db9d9454ca..c46e856b077b 100644
+--- a/security/integrity/ima/ima.h
++++ b/security/integrity/ima/ima.h
+@@ -88,7 +88,7 @@ struct ima_template_desc {
+ 	char *name;
+ 	char *fmt;
+ 	int num_fields;
+-	struct ima_template_field **fields;
++	const struct ima_template_field **fields;
+ };
+ 
+ struct ima_template_entry {
+@@ -191,8 +191,9 @@ enum ima_hooks {
+ };
+ 
+ /* LIM API function definitions */
+-int ima_get_action(struct inode *inode, const struct cred *cred, u32 secid,
+-		   int mask, enum ima_hooks func, int *pcr);
++int ima_get_action(struct inode *inode, const struct cred *cred,
++		   struct lsm_export *l, int mask, enum ima_hooks func,
++		   int *pcr);
+ int ima_must_measure(struct inode *inode, int mask, enum ima_hooks func);
+ int ima_collect_measurement(struct integrity_iint_cache *iint,
+ 			    struct file *file, void *buf, loff_t size,
+@@ -212,8 +213,9 @@ void ima_free_template_entry(struct ima_template_entry *entry);
+ const char *ima_d_path(const struct path *path, char **pathbuf, char *filename);
+ 
+ /* IMA policy related functions */
+-int ima_match_policy(struct inode *inode, const struct cred *cred, u32 secid,
+-		     enum ima_hooks func, int mask, int flags, int *pcr);
++int ima_match_policy(struct inode *inode, const struct cred *cred,
++		     struct lsm_export *l, enum ima_hooks func, int mask,
++		     int flags, int *pcr);
+ void ima_init_policy(void);
+ void ima_update_policy(void);
+ void ima_update_policy_flag(void);
+@@ -306,8 +308,8 @@ static inline int security_filter_rule_init(u32 field, u32 op, char *rulestr,
+ 	return -EINVAL;
+ }
+ 
+-static inline int security_filter_rule_match(u32 secid, u32 field, u32 op,
+-					     void *lsmrule,
++static inline int security_filter_rule_match(struct lsm_export *l, u32 field,
++					     u32 op, void *lsmrule,
+ 					     struct audit_context *actx)
+ {
+ 	return -EINVAL;
+diff --git a/security/integrity/ima/ima_api.c b/security/integrity/ima/ima_api.c
+index a02c5acfd403..6ad5f9d7813b 100644
+--- a/security/integrity/ima/ima_api.c
++++ b/security/integrity/ima/ima_api.c
+@@ -51,7 +51,8 @@ int ima_alloc_init_template(struct ima_event_data *event_data,
+ 
+ 	(*entry)->template_desc = template_desc;
+ 	for (i = 0; i < template_desc->num_fields; i++) {
+-		struct ima_template_field *field = template_desc->fields[i];
++		const struct ima_template_field *field =
++			template_desc->fields[i];
+ 		u32 len;
+ 
+ 		result = field->field_init(event_data,
+@@ -159,7 +160,7 @@ void ima_add_violation(struct file *file, const unsigned char *filename,
+  * ima_get_action - appraise & measure decision based on policy.
+  * @inode: pointer to inode to measure
+  * @cred: pointer to credentials structure to validate
+- * @secid: secid of the task being validated
++ * @l: LAM data of the task being validated
+  * @mask: contains the permission mask (MAY_READ, MAY_WRITE, MAY_EXEC,
+  *        MAY_APPEND)
+  * @func: caller identifier
+@@ -175,14 +176,15 @@ void ima_add_violation(struct file *file, const unsigned char *filename,
+  * Returns IMA_MEASURE, IMA_APPRAISE mask.
+  *
+  */
+-int ima_get_action(struct inode *inode, const struct cred *cred, u32 secid,
+-		   int mask, enum ima_hooks func, int *pcr)
++int ima_get_action(struct inode *inode, const struct cred *cred,
++		   struct lsm_export *l, int mask, enum ima_hooks func,
++		   int *pcr)
+ {
+ 	int flags = IMA_MEASURE | IMA_AUDIT | IMA_APPRAISE | IMA_HASH;
+ 
+ 	flags &= ima_policy_flag;
+ 
+-	return ima_match_policy(inode, cred, secid, func, mask, flags, pcr);
++	return ima_match_policy(inode, cred, l, func, mask, flags, pcr);
+ }
+ 
+ /*
+diff --git a/security/integrity/ima/ima_appraise.c b/security/integrity/ima/ima_appraise.c
+index deec1804a00a..d321da433cda 100644
+--- a/security/integrity/ima/ima_appraise.c
++++ b/security/integrity/ima/ima_appraise.c
+@@ -50,13 +50,13 @@ bool is_ima_appraise_enabled(void)
+  */
+ int ima_must_appraise(struct inode *inode, int mask, enum ima_hooks func)
+ {
+-	u32 secid;
++	struct lsm_export le;
+ 
+ 	if (!ima_appraise)
+ 		return 0;
+ 
+-	security_task_getsecid(current, &secid);
+-	return ima_match_policy(inode, current_cred(), secid, func, mask,
++	security_task_getsecid(current, &le);
++	return ima_match_policy(inode, current_cred(), &le, func, mask,
+ 				IMA_APPRAISE | IMA_HASH, NULL);
+ }
+ 
+diff --git a/security/integrity/ima/ima_crypto.c b/security/integrity/ima/ima_crypto.c
+index f63b4bd45d60..d9e7728027c6 100644
+--- a/security/integrity/ima/ima_crypto.c
++++ b/security/integrity/ima/ima_crypto.c
+@@ -271,16 +271,8 @@ static int ima_calc_file_hash_atfm(struct file *file,
+ 		rbuf_len = min_t(loff_t, i_size - offset, rbuf_size[active]);
+ 		rc = integrity_kernel_read(file, offset, rbuf[active],
+ 					   rbuf_len);
+-		if (rc != rbuf_len) {
+-			if (rc >= 0)
+-				rc = -EINVAL;
+-			/*
+-			 * Forward current rc, do not overwrite with return value
+-			 * from ahash_wait()
+-			 */
+-			ahash_wait(ahash_rc, &wait);
++		if (rc != rbuf_len)
+ 			goto out3;
+-		}
+ 
+ 		if (rbuf[1] && offset) {
+ 			/* Using two buffers, and it is not the first
+diff --git a/security/integrity/ima/ima_fs.c b/security/integrity/ima/ima_fs.c
+index cfb8cc3b975e..3183cc23d0f8 100644
+--- a/security/integrity/ima/ima_fs.c
++++ b/security/integrity/ima/ima_fs.c
+@@ -179,7 +179,8 @@ int ima_measurements_show(struct seq_file *m, void *v)
+ 	/* 6th:  template specific data */
+ 	for (i = 0; i < e->template_desc->num_fields; i++) {
+ 		enum ima_show_type show = IMA_SHOW_BINARY;
+-		struct ima_template_field *field = e->template_desc->fields[i];
++		const struct ima_template_field *field =
++			e->template_desc->fields[i];
+ 
+ 		if (is_ima_template && strcmp(field->field_id, "d") == 0)
+ 			show = IMA_SHOW_BINARY_NO_FIELD_LEN;
+diff --git a/security/integrity/ima/ima_init.c b/security/integrity/ima/ima_init.c
+index faac9ecaa0ae..59d834219cd6 100644
+--- a/security/integrity/ima/ima_init.c
++++ b/security/integrity/ima/ima_init.c
+@@ -25,7 +25,7 @@
+ #include "ima.h"
+ 
+ /* name for boot aggregate entry */
+-static const char *boot_aggregate_name = "boot_aggregate";
++static const char boot_aggregate_name[] = "boot_aggregate";
+ struct tpm_chip *ima_tpm_chip;
+ 
+ /* Add the boot aggregate to the IMA measurement list and extend
+diff --git a/security/integrity/ima/ima_main.c b/security/integrity/ima/ima_main.c
+index 2d31921fbda4..3cfd82a93b89 100644
+--- a/security/integrity/ima/ima_main.c
++++ b/security/integrity/ima/ima_main.c
+@@ -167,8 +167,8 @@ void ima_file_free(struct file *file)
+ }
+ 
+ static int process_measurement(struct file *file, const struct cred *cred,
+-			       u32 secid, char *buf, loff_t size, int mask,
+-			       enum ima_hooks func)
++			       struct lsm_export *l, char *buf, loff_t size,
++			       int mask, enum ima_hooks func)
+ {
+ 	struct inode *inode = file_inode(file);
+ 	struct integrity_iint_cache *iint = NULL;
+@@ -190,7 +190,7 @@ static int process_measurement(struct file *file, const struct cred *cred,
+ 	 * bitmask based on the appraise/audit/measurement policy.
+ 	 * Included is the appraise submask.
+ 	 */
+-	action = ima_get_action(inode, cred, secid, mask, func, &pcr);
++	action = ima_get_action(inode, cred, l, mask, func, &pcr);
+ 	violation_check = ((func == FILE_CHECK || func == MMAP_CHECK) &&
+ 			   (ima_policy_flag & IMA_MEASURE));
+ 	if (!action && !violation_check)
+@@ -333,11 +333,11 @@ static int process_measurement(struct file *file, const struct cred *cred,
+  */
+ int ima_file_mmap(struct file *file, unsigned long prot)
+ {
+-	u32 secid;
++	struct lsm_export le;
+ 
+ 	if (file && (prot & PROT_EXEC)) {
+-		security_task_getsecid(current, &secid);
+-		return process_measurement(file, current_cred(), secid, NULL,
++		security_task_getsecid(current, &le);
++		return process_measurement(file, current_cred(), &le, NULL,
+ 					   0, MAY_EXEC, MMAP_CHECK);
+ 	}
+ 
+@@ -360,16 +360,16 @@ int ima_file_mmap(struct file *file, unsigned long prot)
+ int ima_bprm_check(struct linux_binprm *bprm)
+ {
+ 	int ret;
+-	u32 secid;
++	struct lsm_export le;
+ 
+-	security_task_getsecid(current, &secid);
+-	ret = process_measurement(bprm->file, current_cred(), secid, NULL, 0,
++	security_task_getsecid(current, &le);
++	ret = process_measurement(bprm->file, current_cred(), &le, NULL, 0,
+ 				  MAY_EXEC, BPRM_CHECK);
+ 	if (ret)
+ 		return ret;
+ 
+-	security_cred_getsecid(bprm->cred, &secid);
+-	return process_measurement(bprm->file, bprm->cred, secid, NULL, 0,
++	security_cred_getsecid(bprm->cred, &le);
++	return process_measurement(bprm->file, bprm->cred, &le, NULL, 0,
+ 				   MAY_EXEC, CREDS_CHECK);
+ }
+ 
+@@ -385,10 +385,10 @@ int ima_bprm_check(struct linux_binprm *bprm)
+  */
+ int ima_file_check(struct file *file, int mask)
+ {
+-	u32 secid;
++	struct lsm_export le;
+ 
+-	security_task_getsecid(current, &secid);
+-	return process_measurement(file, current_cred(), secid, NULL, 0,
++	security_task_getsecid(current, &le);
++	return process_measurement(file, current_cred(), &le, NULL, 0,
+ 				   mask & (MAY_READ | MAY_WRITE | MAY_EXEC |
+ 					   MAY_APPEND), FILE_CHECK);
+ }
+@@ -440,7 +440,7 @@ int ima_read_file(struct file *file, enum kernel_read_file_id read_id)
+ 	return 0;
+ }
+ 
+-static int read_idmap[READING_MAX_ID] = {
++static const int read_idmap[READING_MAX_ID] = {
+ 	[READING_FIRMWARE] = FIRMWARE_CHECK,
+ 	[READING_FIRMWARE_PREALLOC_BUFFER] = FIRMWARE_CHECK,
+ 	[READING_MODULE] = MODULE_CHECK,
+@@ -466,7 +466,7 @@ int ima_post_read_file(struct file *file, void *buf, loff_t size,
+ 		       enum kernel_read_file_id read_id)
+ {
+ 	enum ima_hooks func;
+-	u32 secid;
++	struct lsm_export le;
+ 
+ 	if (!file && read_id == READING_FIRMWARE) {
+ 		if ((ima_appraise & IMA_APPRAISE_FIRMWARE) &&
+@@ -488,8 +488,8 @@ int ima_post_read_file(struct file *file, void *buf, loff_t size,
+ 	}
+ 
+ 	func = read_idmap[read_id] ?: FILE_CHECK;
+-	security_task_getsecid(current, &secid);
+-	return process_measurement(file, current_cred(), secid, buf, size,
++	security_task_getsecid(current, &le);
++	return process_measurement(file, current_cred(), &le, buf, size,
+ 				   MAY_READ, func);
+ }
+ 
+diff --git a/security/integrity/ima/ima_policy.c b/security/integrity/ima/ima_policy.c
+index 93babb60b05a..a49f3b742d74 100644
+--- a/security/integrity/ima/ima_policy.c
++++ b/security/integrity/ima/ima_policy.c
+@@ -278,7 +278,7 @@ static void ima_lsm_update_rules(void)
+  * Returns true on rule match, false on failure.
+  */
+ static bool ima_match_rules(struct ima_rule_entry *rule, struct inode *inode,
+-			    const struct cred *cred, u32 secid,
++			    const struct cred *cred, struct lsm_export *l,
+ 			    enum ima_hooks func, int mask)
+ {
+ 	int i;
+@@ -318,7 +318,7 @@ static bool ima_match_rules(struct ima_rule_entry *rule, struct inode *inode,
+ 		return false;
+ 	for (i = 0; i < MAX_LSM_RULES; i++) {
+ 		int rc = 0;
+-		u32 osid;
++		struct lsm_export le;
+ 		int retried = 0;
+ 
+ 		if (!rule->lsm[i].rule)
+@@ -328,8 +328,8 @@ static bool ima_match_rules(struct ima_rule_entry *rule, struct inode *inode,
+ 		case LSM_OBJ_USER:
+ 		case LSM_OBJ_ROLE:
+ 		case LSM_OBJ_TYPE:
+-			security_inode_getsecid(inode, &osid);
+-			rc = security_filter_rule_match(osid,
++			security_inode_getsecid(inode, &le);
++			rc = security_filter_rule_match(&le,
+ 							rule->lsm[i].type,
+ 							Audit_equal,
+ 							rule->lsm[i].rule,
+@@ -338,7 +338,7 @@ static bool ima_match_rules(struct ima_rule_entry *rule, struct inode *inode,
+ 		case LSM_SUBJ_USER:
+ 		case LSM_SUBJ_ROLE:
+ 		case LSM_SUBJ_TYPE:
+-			rc = security_filter_rule_match(secid,
++			rc = security_filter_rule_match(l,
+ 							rule->lsm[i].type,
+ 							Audit_equal,
+ 							rule->lsm[i].rule,
+@@ -387,7 +387,7 @@ static int get_subaction(struct ima_rule_entry *rule, enum ima_hooks func)
+  * @inode: pointer to an inode for which the policy decision is being made
+  * @cred: pointer to a credentials structure for which the policy decision is
+  *        being made
+- * @secid: LSM secid of the task to be validated
++ * @l: LSM data of the task to be validated
+  * @func: IMA hook identifier
+  * @mask: requested action (MAY_READ | MAY_WRITE | MAY_APPEND | MAY_EXEC)
+  * @pcr: set the pcr to extend
+@@ -399,8 +399,9 @@ static int get_subaction(struct ima_rule_entry *rule, enum ima_hooks func)
+  * list when walking it.  Reads are many orders of magnitude more numerous
+  * than writes so ima_match_policy() is classical RCU candidate.
+  */
+-int ima_match_policy(struct inode *inode, const struct cred *cred, u32 secid,
+-		     enum ima_hooks func, int mask, int flags, int *pcr)
++int ima_match_policy(struct inode *inode, const struct cred *cred,
++		     struct lsm_export *l, enum ima_hooks func, int mask,
++		     int flags, int *pcr)
+ {
+ 	struct ima_rule_entry *entry;
+ 	int action = 0, actmask = flags | (flags << 1);
+@@ -411,7 +412,7 @@ int ima_match_policy(struct inode *inode, const struct cred *cred, u32 secid,
+ 		if (!(entry->action & actmask))
+ 			continue;
+ 
+-		if (!ima_match_rules(entry, inode, cred, secid, func, mask))
++		if (!ima_match_rules(entry, inode, cred, l, func, mask))
+ 			continue;
+ 
+ 		action |= entry->flags & IMA_ACTION_FLAGS;
+@@ -1059,10 +1060,10 @@ enum {
+ };
+ 
+ static const char *const mask_tokens[] = {
+-	"^MAY_EXEC",
+-	"^MAY_WRITE",
+-	"^MAY_READ",
+-	"^MAY_APPEND"
++	"MAY_EXEC",
++	"MAY_WRITE",
++	"MAY_READ",
++	"MAY_APPEND"
+ };
+ 
+ #define __ima_hook_stringify(str)	(#str),
+@@ -1122,7 +1123,6 @@ int ima_policy_show(struct seq_file *m, void *v)
+ 	struct ima_rule_entry *entry = v;
+ 	int i;
+ 	char tbuf[64] = {0,};
+-	int offset = 0;
+ 
+ 	rcu_read_lock();
+ 
+@@ -1146,17 +1146,15 @@ int ima_policy_show(struct seq_file *m, void *v)
+ 	if (entry->flags & IMA_FUNC)
+ 		policy_func_show(m, entry->func);
+ 
+-	if ((entry->flags & IMA_MASK) || (entry->flags & IMA_INMASK)) {
+-		if (entry->flags & IMA_MASK)
+-			offset = 1;
++	if (entry->flags & IMA_MASK) {
+ 		if (entry->mask & MAY_EXEC)
+-			seq_printf(m, pt(Opt_mask), mt(mask_exec) + offset);
++			seq_printf(m, pt(Opt_mask), mt(mask_exec));
+ 		if (entry->mask & MAY_WRITE)
+-			seq_printf(m, pt(Opt_mask), mt(mask_write) + offset);
++			seq_printf(m, pt(Opt_mask), mt(mask_write));
+ 		if (entry->mask & MAY_READ)
+-			seq_printf(m, pt(Opt_mask), mt(mask_read) + offset);
++			seq_printf(m, pt(Opt_mask), mt(mask_read));
+ 		if (entry->mask & MAY_APPEND)
+-			seq_printf(m, pt(Opt_mask), mt(mask_append) + offset);
++			seq_printf(m, pt(Opt_mask), mt(mask_append));
+ 		seq_puts(m, " ");
+ 	}
+ 
+diff --git a/security/integrity/ima/ima_template.c b/security/integrity/ima/ima_template.c
+index 30db39b23804..b631b8bc7624 100644
+--- a/security/integrity/ima/ima_template.c
++++ b/security/integrity/ima/ima_template.c
+@@ -32,7 +32,7 @@ static struct ima_template_desc builtin_templates[] = {
+ static LIST_HEAD(defined_templates);
+ static DEFINE_SPINLOCK(template_list);
+ 
+-static struct ima_template_field supported_fields[] = {
++static const struct ima_template_field supported_fields[] = {
+ 	{.field_id = "d", .field_init = ima_eventdigest_init,
+ 	 .field_show = ima_show_template_digest},
+ 	{.field_id = "n", .field_init = ima_eventname_init,
+@@ -49,7 +49,7 @@ static struct ima_template_field supported_fields[] = {
+ static struct ima_template_desc *ima_template;
+ static struct ima_template_desc *lookup_template_desc(const char *name);
+ static int template_desc_init_fields(const char *template_fmt,
+-				     struct ima_template_field ***fields,
++				     const struct ima_template_field ***fields,
+ 				     int *num_fields);
+ 
+ static int __init ima_template_setup(char *str)
+@@ -125,7 +125,8 @@ static struct ima_template_desc *lookup_template_desc(const char *name)
+ 	return found ? template_desc : NULL;
+ }
+ 
+-static struct ima_template_field *lookup_template_field(const char *field_id)
++static const struct ima_template_field *
++lookup_template_field(const char *field_id)
+ {
+ 	int i;
+ 
+@@ -153,11 +154,11 @@ static int template_fmt_size(const char *template_fmt)
+ }
+ 
+ static int template_desc_init_fields(const char *template_fmt,
+-				     struct ima_template_field ***fields,
++				     const struct ima_template_field ***fields,
+ 				     int *num_fields)
+ {
+ 	const char *template_fmt_ptr;
+-	struct ima_template_field *found_fields[IMA_TEMPLATE_NUM_FIELDS_MAX];
++	const struct ima_template_field *found_fields[IMA_TEMPLATE_NUM_FIELDS_MAX];
+ 	int template_num_fields;
+ 	int i, len;
+ 
+diff --git a/security/loadpin/Kconfig b/security/loadpin/Kconfig
+index dd01aa91e521..a0d70d82b98e 100644
+--- a/security/loadpin/Kconfig
++++ b/security/loadpin/Kconfig
+@@ -10,10 +10,10 @@ config SECURITY_LOADPIN
+ 	  have a root filesystem backed by a read-only device such as
+ 	  dm-verity or a CDROM.
+ 
+-config SECURITY_LOADPIN_ENABLED
++config SECURITY_LOADPIN_ENFORCE
+ 	bool "Enforce LoadPin at boot"
+ 	depends on SECURITY_LOADPIN
+ 	help
+ 	  If selected, LoadPin will enforce pinning at boot. If not
+ 	  selected, it can be enabled at boot with the kernel parameter
+-	  "loadpin.enabled=1".
++	  "loadpin.enforce=1".
+diff --git a/security/loadpin/loadpin.c b/security/loadpin/loadpin.c
+index 379fcb8e9aeb..055fb0a64169 100644
+--- a/security/loadpin/loadpin.c
++++ b/security/loadpin/loadpin.c
+@@ -44,9 +44,7 @@ static void report_load(const char *origin, struct file *file, char *operation)
+ 	kfree(pathname);
+ }
+ 
+-static int enabled = IS_ENABLED(CONFIG_SECURITY_LOADPIN_ENABLED);
+-static char *exclude_read_files[READING_MAX_ID];
+-static int ignore_read_file_id[READING_MAX_ID] __ro_after_init;
++static int enforce = IS_ENABLED(CONFIG_SECURITY_LOADPIN_ENFORCE);
+ static struct super_block *pinned_root;
+ static DEFINE_SPINLOCK(pinned_root_spinlock);
+ 
+@@ -62,8 +60,8 @@ static struct ctl_path loadpin_sysctl_path[] = {
+ 
+ static struct ctl_table loadpin_sysctl_table[] = {
+ 	{
+-		.procname       = "enabled",
+-		.data           = &enabled,
++		.procname       = "enforce",
++		.data           = &enforce,
+ 		.maxlen         = sizeof(int),
+ 		.mode           = 0644,
+ 		.proc_handler   = proc_dointvec_minmax,
+@@ -86,8 +84,11 @@ static void check_pinning_enforcement(struct super_block *mnt_sb)
+ 	 * device, allow sysctl to change modes for testing.
+ 	 */
+ 	if (mnt_sb->s_bdev) {
++		char bdev[BDEVNAME_SIZE];
++
+ 		ro = bdev_read_only(mnt_sb->s_bdev);
+-		pr_info("dev(%u,%u): %s\n",
++		bdevname(mnt_sb->s_bdev, bdev);
++		pr_info("%s (%u:%u): %s\n", bdev,
+ 			MAJOR(mnt_sb->s_bdev->bd_dev),
+ 			MINOR(mnt_sb->s_bdev->bd_dev),
+ 			ro ? "read-only" : "writable");
+@@ -99,7 +100,7 @@ static void check_pinning_enforcement(struct super_block *mnt_sb)
+ 					   loadpin_sysctl_table))
+ 			pr_notice("sysctl registration failed!\n");
+ 		else
+-			pr_info("load pinning can be disabled.\n");
++			pr_info("enforcement can be disabled.\n");
+ 	} else
+ 		pr_info("load pinning engaged.\n");
+ }
+@@ -128,16 +129,9 @@ static int loadpin_read_file(struct file *file, enum kernel_read_file_id id)
+ 	struct super_block *load_root;
+ 	const char *origin = kernel_read_file_id_str(id);
+ 
+-	/* If the file id is excluded, ignore the pinning. */
+-	if ((unsigned int)id < ARRAY_SIZE(ignore_read_file_id) &&
+-	    ignore_read_file_id[id]) {
+-		report_load(origin, file, "pinning-excluded");
+-		return 0;
+-	}
+-
+ 	/* This handles the older init_module API that has a NULL file. */
+ 	if (!file) {
+-		if (!enabled) {
++		if (!enforce) {
+ 			report_load(origin, NULL, "old-api-pinning-ignored");
+ 			return 0;
+ 		}
+@@ -160,7 +154,7 @@ static int loadpin_read_file(struct file *file, enum kernel_read_file_id id)
+ 		 * Unlock now since it's only pinned_root we care about.
+ 		 * In the worst case, we will (correctly) report pinning
+ 		 * failures before we have announced that pinning is
+-		 * enabled. This would be purely cosmetic.
++		 * enforcing. This would be purely cosmetic.
+ 		 */
+ 		spin_unlock(&pinned_root_spinlock);
+ 		check_pinning_enforcement(pinned_root);
+@@ -170,7 +164,7 @@ static int loadpin_read_file(struct file *file, enum kernel_read_file_id id)
+ 	}
+ 
+ 	if (IS_ERR_OR_NULL(pinned_root) || load_root != pinned_root) {
+-		if (unlikely(!enabled)) {
++		if (unlikely(!enforce)) {
+ 			report_load(origin, file, "pinning-ignored");
+ 			return 0;
+ 		}
+@@ -193,51 +187,19 @@ static struct security_hook_list loadpin_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(kernel_load_data, loadpin_load_data),
+ };
+ 
+-static void __init parse_exclude(void)
+-{
+-	int i, j;
+-	char *cur;
+-
+-	/*
+-	 * Make sure all the arrays stay within expected sizes. This
+-	 * is slightly weird because kernel_read_file_str[] includes
+-	 * READING_MAX_ID, which isn't actually meaningful here.
+-	 */
+-	BUILD_BUG_ON(ARRAY_SIZE(exclude_read_files) !=
+-		     ARRAY_SIZE(ignore_read_file_id));
+-	BUILD_BUG_ON(ARRAY_SIZE(kernel_read_file_str) <
+-		     ARRAY_SIZE(ignore_read_file_id));
+-
+-	for (i = 0; i < ARRAY_SIZE(exclude_read_files); i++) {
+-		cur = exclude_read_files[i];
+-		if (!cur)
+-			break;
+-		if (*cur == '\0')
+-			continue;
+-
+-		for (j = 0; j < ARRAY_SIZE(ignore_read_file_id); j++) {
+-			if (strcmp(cur, kernel_read_file_str[j]) == 0) {
+-				pr_info("excluding: %s\n",
+-					kernel_read_file_str[j]);
+-				ignore_read_file_id[j] = 1;
+-				/*
+-				 * Can not break, because one read_file_str
+-				 * may map to more than on read_file_id.
+-				 */
+-			}
+-		}
+-	}
+-}
+-
+-void __init loadpin_add_hooks(void)
++static int __init loadpin_init(void)
+ {
+-	pr_info("ready to pin (currently %sabled)", enabled ? "en" : "dis");
+-	parse_exclude();
++	pr_info("ready to pin (currently %senforcing)\n",
++		enforce ? "" : "not ");
+ 	security_add_hooks(loadpin_hooks, ARRAY_SIZE(loadpin_hooks), "loadpin");
++	return 0;
+ }
+ 
++DEFINE_LSM(loadpin) = {
++	.name = "loadpin",
++	.init = loadpin_init,
++};
++
+ /* Should not be mutable after boot, so not listed in sysfs (perm == 0). */
+-module_param(enabled, int, 0);
+-MODULE_PARM_DESC(enabled, "Pin module/firmware loading (default: true)");
+-module_param_array_named(exclude, exclude_read_files, charp, NULL, 0);
+-MODULE_PARM_DESC(exclude, "Exclude pinning specific read file types");
++module_param(enforce, int, 0);
++MODULE_PARM_DESC(enforce, "Enforce module/firmware pinning");
+diff --git a/security/lsm_audit.c b/security/lsm_audit.c
+index 33028c098ef3..f84001019356 100644
+--- a/security/lsm_audit.c
++++ b/security/lsm_audit.c
+@@ -321,7 +321,6 @@ static void dump_common_audit_data(struct audit_buffer *ab,
+ 		if (a->u.net->sk) {
+ 			struct sock *sk = a->u.net->sk;
+ 			struct unix_sock *u;
+-			struct unix_address *addr;
+ 			int len = 0;
+ 			char *p = NULL;
+ 
+@@ -352,15 +351,14 @@ static void dump_common_audit_data(struct audit_buffer *ab,
+ #endif
+ 			case AF_UNIX:
+ 				u = unix_sk(sk);
+-				addr = smp_load_acquire(&u->addr);
+-				if (!addr)
+-					break;
+ 				if (u->path.dentry) {
+ 					audit_log_d_path(ab, " path=", &u->path);
+ 					break;
+ 				}
+-				len = addr->len-sizeof(short);
+-				p = &addr->name->sun_path[0];
++				if (!u->addr)
++					break;
++				len = u->addr->len-sizeof(short);
++				p = &u->addr->name->sun_path[0];
+ 				audit_log_format(ab, " path=");
+ 				if (*p)
+ 					audit_log_untrustedstring(ab, p);
+diff --git a/security/security.c b/security/security.c
+index 75d9141d46aa..1b63cf281de4 100644
+--- a/security/security.c
++++ b/security/security.c
+@@ -12,6 +12,8 @@
+  *	(at your option) any later version.
+  */
+ 
++#define pr_fmt(fmt) "LSM: " fmt
++
+ #include <linux/bpf.h>
+ #include <linux/capability.h>
+ #include <linux/dcache.h>
+@@ -28,40 +30,324 @@
+ #include <linux/personality.h>
+ #include <linux/backing-dev.h>
+ #include <linux/string.h>
++#include <linux/msg.h>
+ #include <net/flow.h>
+-
+-#include <trace/events/initcall.h>
++#include <net/sock.h>
+ 
+ #define MAX_LSM_EVM_XATTR	2
+ 
+-/* Maximum number of letters for an LSM name string */
+-#define SECURITY_NAME_MAX	10
++/* How many LSMs were built into the kernel? */
++#define LSM_COUNT (__end_lsm_info - __start_lsm_info)
+ 
+ struct security_hook_heads security_hook_heads __lsm_ro_after_init;
+ static ATOMIC_NOTIFIER_HEAD(lsm_notifier_chain);
+ 
++static struct kmem_cache *lsm_file_cache;
++static struct kmem_cache *lsm_inode_cache;
++
+ char *lsm_names;
++
++/*
++ *	Socket blobs include infrastructure managed data
++ *	Cred blobs include context display instructions
++ */
++static struct lsm_blob_sizes blob_sizes __lsm_ro_after_init = {
++	.lbs_sock = sizeof(struct lsm_export),
++	.lbs_cred = sizeof(struct lsm_one_hooks),
++};
++
++/**
++ * lsm_export_skb - pointer to the lsm_export associated with the skb
++ * @skb: the socket buffer
++ *
++ * Returns a pointer to the LSM managed data.
++ */
++struct lsm_export *lsm_export_skb(struct sk_buff *skb)
++{
++	return skb->sk->sk_security;
++}
++
+ /* Boot-time LSM user choice */
+-static __initdata char chosen_lsm[SECURITY_NAME_MAX + 1] =
+-	CONFIG_DEFAULT_SECURITY;
++static __initdata const char *chosen_lsm_order;
++static __initdata const char *chosen_major_lsm;
+ 
+-static void __init do_security_initcalls(void)
++static __initconst const char * const builtin_lsm_order = CONFIG_LSM;
++
++/* Ordered list of LSMs to initialize. */
++static __initdata struct lsm_info **ordered_lsms;
++static __initdata struct lsm_info *exclusive;
++
++static __initdata bool debug;
++#define init_debug(...)						\
++	do {							\
++		if (debug)					\
++			pr_info(__VA_ARGS__);			\
++	} while (0)
++
++static bool __init is_enabled(struct lsm_info *lsm)
+ {
+-	int ret;
+-	initcall_t call;
+-	initcall_entry_t *ce;
+-
+-	ce = __security_initcall_start;
+-	trace_initcall_level("security");
+-	while (ce < __security_initcall_end) {
+-		call = initcall_from_entry(ce);
+-		trace_initcall_start(call);
+-		ret = call();
+-		trace_initcall_finish(call, ret);
+-		ce++;
++	if (!lsm->enabled)
++		return false;
++
++	return *lsm->enabled;
++}
++
++/* Mark an LSM's enabled flag. */
++static int lsm_enabled_true __initdata = 1;
++static int lsm_enabled_false __initdata = 0;
++static void __init set_enabled(struct lsm_info *lsm, bool enabled)
++{
++	/*
++	 * When an LSM hasn't configured an enable variable, we can use
++	 * a hard-coded location for storing the default enabled state.
++	 */
++	if (!lsm->enabled) {
++		if (enabled)
++			lsm->enabled = &lsm_enabled_true;
++		else
++			lsm->enabled = &lsm_enabled_false;
++	} else if (lsm->enabled == &lsm_enabled_true) {
++		if (!enabled)
++			lsm->enabled = &lsm_enabled_false;
++	} else if (lsm->enabled == &lsm_enabled_false) {
++		if (enabled)
++			lsm->enabled = &lsm_enabled_true;
++	} else {
++		*lsm->enabled = enabled;
++	}
++}
++
++/* Is an LSM already listed in the ordered LSMs list? */
++static bool __init exists_ordered_lsm(struct lsm_info *lsm)
++{
++	struct lsm_info **check;
++
++	for (check = ordered_lsms; *check; check++)
++		if (*check == lsm)
++			return true;
++
++	return false;
++}
++
++/* Append an LSM to the list of ordered LSMs to initialize. */
++static int last_lsm __initdata;
++static void __init append_ordered_lsm(struct lsm_info *lsm, const char *from)
++{
++	/* Ignore duplicate selections. */
++	if (exists_ordered_lsm(lsm))
++		return;
++
++	if (WARN(last_lsm == LSM_COUNT, "%s: out of LSM slots!?\n", from))
++		return;
++
++	/* Enable this LSM, if it is not already set. */
++	if (!lsm->enabled)
++		lsm->enabled = &lsm_enabled_true;
++	ordered_lsms[last_lsm++] = lsm;
++
++	init_debug("%s ordering: %s (%sabled)\n", from, lsm->name,
++		   is_enabled(lsm) ? "en" : "dis");
++}
++
++/* Is an LSM allowed to be initialized? */
++static bool __init lsm_allowed(struct lsm_info *lsm)
++{
++	/* Skip if the LSM is disabled. */
++	if (!is_enabled(lsm))
++		return false;
++
++	/* Not allowed if another exclusive LSM already initialized. */
++	if ((lsm->flags & LSM_FLAG_EXCLUSIVE) && exclusive) {
++		init_debug("exclusive disabled: %s\n", lsm->name);
++		return false;
++	}
++
++	return true;
++}
++
++static void __init lsm_set_blob_size(int *need, int *lbs)
++{
++	int offset;
++
++	if (*need > 0) {
++		offset = *lbs;
++		*lbs += *need;
++		*need = offset;
+ 	}
+ }
+ 
++static void __init lsm_set_blob_sizes(struct lsm_blob_sizes *needed)
++{
++	if (!needed)
++		return;
++
++	lsm_set_blob_size(&needed->lbs_cred, &blob_sizes.lbs_cred);
++	lsm_set_blob_size(&needed->lbs_file, &blob_sizes.lbs_file);
++	/*
++	 * The inode blob gets an rcu_head in addition to
++	 * what the modules might need.
++	 */
++	if (needed->lbs_inode && blob_sizes.lbs_inode == 0)
++		blob_sizes.lbs_inode = sizeof(struct rcu_head);
++	lsm_set_blob_size(&needed->lbs_inode, &blob_sizes.lbs_inode);
++	lsm_set_blob_size(&needed->lbs_ipc, &blob_sizes.lbs_ipc);
++#ifdef CONFIG_KEYS
++	lsm_set_blob_size(&needed->lbs_key, &blob_sizes.lbs_key);
++#endif
++	lsm_set_blob_size(&needed->lbs_msg_msg, &blob_sizes.lbs_msg_msg);
++	lsm_set_blob_size(&needed->lbs_sock, &blob_sizes.lbs_sock);
++	lsm_set_blob_size(&needed->lbs_superblock, &blob_sizes.lbs_superblock);
++	lsm_set_blob_size(&needed->lbs_task, &blob_sizes.lbs_task);
++}
++
++/* Prepare LSM for initialization. */
++static void __init prepare_lsm(struct lsm_info *lsm)
++{
++	int enabled = lsm_allowed(lsm);
++
++	/* Record enablement (to handle any following exclusive LSMs). */
++	set_enabled(lsm, enabled);
++
++	/* If enabled, do pre-initialization work. */
++	if (enabled) {
++		if ((lsm->flags & LSM_FLAG_EXCLUSIVE) && !exclusive) {
++			exclusive = lsm;
++			init_debug("exclusive chosen: %s\n", lsm->name);
++		}
++
++		lsm_set_blob_sizes(lsm->blobs);
++	}
++}
++
++/* Initialize a given LSM, if it is enabled. */
++static void __init initialize_lsm(struct lsm_info *lsm)
++{
++	if (is_enabled(lsm)) {
++		int ret;
++
++		init_debug("initializing %s\n", lsm->name);
++		ret = lsm->init();
++		WARN(ret, "%s failed to initialize: %d\n", lsm->name, ret);
++	}
++}
++
++/* Populate ordered LSMs list from comma-separated LSM name list. */
++static void __init ordered_lsm_parse(const char *order, const char *origin)
++{
++	struct lsm_info *lsm;
++	char *sep, *name, *next;
++
++	/* LSM_ORDER_FIRST is always first. */
++	for (lsm = __start_lsm_info; lsm < __end_lsm_info; lsm++) {
++		if (lsm->order == LSM_ORDER_FIRST)
++			append_ordered_lsm(lsm, "first");
++	}
++
++	/* Process "security=", if given. */
++	if (chosen_major_lsm) {
++		struct lsm_info *major;
++
++		/*
++		 * To match the original "security=" behavior, this
++		 * explicitly does NOT fallback to another Legacy Major
++		 * if the selected one was separately disabled: disable
++		 * all non-matching Legacy Major LSMs.
++		 */
++		for (major = __start_lsm_info; major < __end_lsm_info;
++		     major++) {
++			if ((major->flags & LSM_FLAG_LEGACY_MAJOR) &&
++			    strcmp(major->name, chosen_major_lsm) != 0) {
++				set_enabled(major, false);
++				init_debug("security=%s disabled: %s\n",
++					   chosen_major_lsm, major->name);
++			}
++		}
++	}
++
++	sep = kstrdup(order, GFP_KERNEL);
++	next = sep;
++	/* Walk the list, looking for matching LSMs. */
++	while ((name = strsep(&next, ",")) != NULL) {
++		bool found = false;
++
++		for (lsm = __start_lsm_info; lsm < __end_lsm_info; lsm++) {
++			if (lsm->order == LSM_ORDER_MUTABLE &&
++			    strcmp(lsm->name, name) == 0) {
++				append_ordered_lsm(lsm, origin);
++				found = true;
++			}
++		}
++
++		if (!found)
++			init_debug("%s ignored: %s\n", origin, name);
++	}
++
++	/* Process "security=", if given. */
++	if (chosen_major_lsm) {
++		for (lsm = __start_lsm_info; lsm < __end_lsm_info; lsm++) {
++			if (exists_ordered_lsm(lsm))
++				continue;
++			if (strcmp(lsm->name, chosen_major_lsm) == 0)
++				append_ordered_lsm(lsm, "security=");
++		}
++	}
++
++	/* Disable all LSMs not in the ordered list. */
++	for (lsm = __start_lsm_info; lsm < __end_lsm_info; lsm++) {
++		if (exists_ordered_lsm(lsm))
++			continue;
++		set_enabled(lsm, false);
++		init_debug("%s disabled: %s\n", origin, lsm->name);
++	}
++
++	kfree(sep);
++}
++
++static void __init ordered_lsm_init(void)
++{
++	struct lsm_info **lsm;
++
++	ordered_lsms = kcalloc(LSM_COUNT + 1, sizeof(*ordered_lsms),
++				GFP_KERNEL);
++
++	if (chosen_lsm_order)
++		ordered_lsm_parse(chosen_lsm_order, "cmdline");
++	else
++		ordered_lsm_parse(builtin_lsm_order, "builtin");
++
++	for (lsm = ordered_lsms; *lsm; lsm++)
++		prepare_lsm(*lsm);
++
++	init_debug("cred blob size       = %d\n", blob_sizes.lbs_cred);
++	init_debug("file blob size       = %d\n", blob_sizes.lbs_file);
++	init_debug("inode blob size      = %d\n", blob_sizes.lbs_inode);
++	init_debug("ipc blob size        = %d\n", blob_sizes.lbs_ipc);
++#ifdef CONFIG_KEYS
++	init_debug("key blob size        = %d\n", blob_sizes.lbs_key);
++#endif /* CONFIG_KEYS */
++	init_debug("msg_msg blob size    = %d\n", blob_sizes.lbs_msg_msg);
++	init_debug("sock blob size       = %d\n", blob_sizes.lbs_sock);
++	init_debug("superblock blob size = %d\n", blob_sizes.lbs_superblock);
++	init_debug("task blob size       = %d\n", blob_sizes.lbs_task);
++
++	/*
++	 * Create any kmem_caches needed for blobs
++	 */
++	if (blob_sizes.lbs_file)
++		lsm_file_cache = kmem_cache_create("lsm_file_cache",
++						   blob_sizes.lbs_file, 0,
++						   SLAB_PANIC, NULL);
++	if (blob_sizes.lbs_inode)
++		lsm_inode_cache = kmem_cache_create("lsm_inode_cache",
++						    blob_sizes.lbs_inode, 0,
++						    SLAB_PANIC, NULL);
++
++	for (lsm = ordered_lsms; *lsm; lsm++)
++		initialize_lsm(*lsm);
++
++	kfree(ordered_lsms);
++}
++
+ /**
+  * security_init - initializes the security framework
+  *
+@@ -72,33 +358,41 @@ int __init security_init(void)
+ 	int i;
+ 	struct hlist_head *list = (struct hlist_head *) &security_hook_heads;
+ 
++	pr_info("Security Framework initializing\n");
++
+ 	for (i = 0; i < sizeof(security_hook_heads) / sizeof(struct hlist_head);
+ 	     i++)
+ 		INIT_HLIST_HEAD(&list[i]);
+-	pr_info("Security Framework initialized\n");
+ 
+-	/*
+-	 * Load minor LSMs, with the capability module always first.
+-	 */
+-	capability_add_hooks();
+-	yama_add_hooks();
+-	loadpin_add_hooks();
+-
+-	/*
+-	 * Load all the remaining security modules.
+-	 */
+-	do_security_initcalls();
++	/* Load LSMs in specified order. */
++	ordered_lsm_init();
+ 
+ 	return 0;
+ }
+ 
+ /* Save user chosen LSM */
+-static int __init choose_lsm(char *str)
++static int __init choose_major_lsm(char *str)
++{
++	chosen_major_lsm = str;
++	return 1;
++}
++__setup("security=", choose_major_lsm);
++
++/* Explicitly choose LSM initialization order. */
++static int __init choose_lsm_order(char *str)
+ {
+-	strncpy(chosen_lsm, str, SECURITY_NAME_MAX);
++	chosen_lsm_order = str;
+ 	return 1;
+ }
+-__setup("security=", choose_lsm);
++__setup("lsm=", choose_lsm_order);
++
++/* Enable LSM order debugging. */
++static int __init enable_debug(char *str)
++{
++	debug = true;
++	return 1;
++}
++__setup("lsm.debug", enable_debug);
+ 
+ static bool match_last_lsm(const char *list, const char *lsm)
+ {
+@@ -136,28 +430,11 @@ static int lsm_append(char *new, char **result)
+ 	return 0;
+ }
+ 
+-/**
+- * security_module_enable - Load given security module on boot ?
+- * @module: the name of the module
+- *
+- * Each LSM must pass this method before registering its own operations
+- * to avoid security registration races. This method may also be used
+- * to check if your LSM is currently loaded during kernel initialization.
+- *
+- * Returns:
+- *
+- * true if:
+- *
+- * - The passed LSM is the one chosen by user at boot time,
+- * - or the passed LSM is configured as the default and the user did not
+- *   choose an alternate LSM at boot time.
+- *
+- * Otherwise, return false.
+- */
+-int __init security_module_enable(const char *module)
+-{
+-	return !strcmp(module, chosen_lsm);
+-}
++/* Base list of once-only hooks */
++struct lsm_one_hooks lsm_base_one;
++
++/* Count of inode_[gs]etsecctx hooks */
++static int lsm_inode_secctx_count;
+ 
+ /**
+  * security_add_hooks - Add a modules hooks to the hook lists.
+@@ -175,6 +452,43 @@ void __init security_add_hooks(struct security_hook_list *hooks, int count,
+ 	for (i = 0; i < count; i++) {
+ 		hooks[i].lsm = lsm;
+ 		hlist_add_tail_rcu(&hooks[i].list, hooks[i].head);
++
++		/*
++		 * Keep count of the internal security context using hooks.
++		 * Assume that there is a 1:1 mapping from inode_getsecctx
++		 * to inode_setsecctx in the security modules.
++		 */
++		if (hooks[i].head == &security_hook_heads.inode_getsecctx) {
++			lsm_inode_secctx_count++;
++			continue;
++		}
++		/*
++		 * Check for the special hooks that are restricted to
++		 * a single module to create the base set. Use the hooks
++		 * from that module for the set, which may not be complete.
++		 */
++		if (lsm_base_one.lsm && strcmp(lsm_base_one.lsm, hooks[i].lsm))
++			continue;
++		if (hooks[i].head == &security_hook_heads.secid_to_secctx)
++			lsm_base_one.secid_to_secctx = hooks[i].hook;
++		else if (hooks[i].head == &security_hook_heads.secctx_to_secid)
++			lsm_base_one.secctx_to_secid = hooks[i].hook;
++		else if (hooks[i].head ==
++				&security_hook_heads.socket_getpeersec_stream)
++			lsm_base_one.socket_getpeersec_stream = hooks[i].hook;
++		else if (hooks[i].head ==
++				&security_hook_heads.secmark_relabel_packet)
++			lsm_base_one.secmark_relabel_packet = hooks[i].hook;
++		else if (hooks[i].head ==
++				&security_hook_heads.secmark_refcount_inc)
++			lsm_base_one.secmark_refcount_inc = hooks[i].hook;
++		else if (hooks[i].head ==
++				&security_hook_heads.secmark_refcount_dec)
++			lsm_base_one.secmark_refcount_dec = hooks[i].hook;
++		else
++			continue;
++		if (lsm_base_one.lsm == NULL)
++			lsm_base_one.lsm = kstrdup(hooks[i].lsm, GFP_KERNEL);
+ 	}
+ 	if (lsm_append(lsm, &lsm_names) < 0)
+ 		panic("%s - Cannot get early memory.\n", __func__);
+@@ -198,6 +512,237 @@ int unregister_lsm_notifier(struct notifier_block *nb)
+ }
+ EXPORT_SYMBOL(unregister_lsm_notifier);
+ 
++/**
++ * lsm_cred_alloc - allocate a composite cred blob
++ * @cred: the cred that needs a blob
++ * @gfp: allocation type
++ *
++ * Allocate the cred blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++static int lsm_cred_alloc(struct cred *cred, gfp_t gfp)
++{
++	if (blob_sizes.lbs_cred == 0) {
++		cred->security = NULL;
++		return 0;
++	}
++
++	cred->security = kzalloc(blob_sizes.lbs_cred, gfp);
++	if (cred->security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_early_cred - during initialization allocate a composite cred blob
++ * @cred: the cred that needs a blob
++ *
++ * Allocate the cred blob for all the modules if it's not already there
++ */
++void __init lsm_early_cred(struct cred *cred)
++{
++	int rc;
++
++	if (cred == NULL)
++		panic("%s: NULL cred.\n", __func__);
++	if (cred->security != NULL)
++		return;
++	rc = lsm_cred_alloc(cred, GFP_KERNEL);
++	if (rc)
++		panic("%s: Early cred alloc failed.\n", __func__);
++}
++
++/**
++ * lsm_file_alloc - allocate a composite file blob
++ * @file: the file that needs a blob
++ *
++ * Allocate the file blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++static int lsm_file_alloc(struct file *file)
++{
++	if (!lsm_file_cache) {
++		file->f_security = NULL;
++		return 0;
++	}
++
++	file->f_security = kmem_cache_zalloc(lsm_file_cache, GFP_KERNEL);
++	if (file->f_security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_inode_alloc - allocate a composite inode blob
++ * @inode: the inode that needs a blob
++ *
++ * Allocate the inode blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_inode_alloc(struct inode *inode)
++{
++	if (!lsm_inode_cache) {
++		inode->i_security = NULL;
++		return 0;
++	}
++
++	inode->i_security = kmem_cache_zalloc(lsm_inode_cache, GFP_NOFS);
++	if (inode->i_security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_task_alloc - allocate a composite task blob
++ * @task: the task that needs a blob
++ *
++ * Allocate the task blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_task_alloc(struct task_struct *task)
++{
++	if (blob_sizes.lbs_task == 0) {
++		task->security = NULL;
++		return 0;
++	}
++
++	task->security = kzalloc(blob_sizes.lbs_task, GFP_KERNEL);
++	if (task->security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_ipc_alloc - allocate a composite ipc blob
++ * @kip: the ipc that needs a blob
++ *
++ * Allocate the ipc blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_ipc_alloc(struct kern_ipc_perm *kip)
++{
++	if (blob_sizes.lbs_ipc == 0) {
++		kip->security = NULL;
++		return 0;
++	}
++
++	kip->security = kzalloc(blob_sizes.lbs_ipc, GFP_KERNEL);
++	if (kip->security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++#ifdef CONFIG_KEYS
++/**
++ * lsm_key_alloc - allocate a composite key blob
++ * @key: the key that needs a blob
++ *
++ * Allocate the key blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_key_alloc(struct key *key)
++{
++	if (blob_sizes.lbs_key == 0) {
++		key->security = NULL;
++		return 0;
++	}
++
++	key->security = kzalloc(blob_sizes.lbs_key, GFP_KERNEL);
++	if (key->security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++#endif /* CONFIG_KEYS */
++
++/**
++ * lsm_msg_msg_alloc - allocate a composite msg_msg blob
++ * @mp: the msg_msg that needs a blob
++ *
++ * Allocate the ipc blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_msg_msg_alloc(struct msg_msg *mp)
++{
++	if (blob_sizes.lbs_msg_msg == 0) {
++		mp->security = NULL;
++		return 0;
++	}
++
++	mp->security = kzalloc(blob_sizes.lbs_msg_msg, GFP_KERNEL);
++	if (mp->security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_early_task - during initialization allocate a composite task blob
++ * @task: the task that needs a blob
++ *
++ * Allocate the task blob for all the modules if it's not already there
++ */
++void __init lsm_early_task(struct task_struct *task)
++{
++	int rc;
++
++	if (task == NULL)
++		panic("%s: task cred.\n", __func__);
++	if (task->security != NULL)
++		return;
++	rc = lsm_task_alloc(task);
++	if (rc)
++		panic("%s: Early task alloc failed.\n", __func__);
++}
++
++/**
++ * lsm_sock_alloc - allocate a composite sock blob
++ * @sock: the sock that needs a blob
++ * @priority: allocation mode
++ *
++ * Allocate the sock blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_sock_alloc(struct sock *sock, gfp_t priority)
++{
++	if (blob_sizes.lbs_sock == 0) {
++		sock->sk_security = NULL;
++		return 0;
++	}
++
++	sock->sk_security = kzalloc(blob_sizes.lbs_sock, priority);
++	if (sock->sk_security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * lsm_superblock_alloc - allocate a composite superblock blob
++ * @sb: the superblock that needs a blob
++ *
++ * Allocate the superblock blob for all the modules
++ *
++ * Returns 0, or -ENOMEM if memory can't be allocated.
++ */
++int lsm_superblock_alloc(struct super_block *sb)
++{
++	if (blob_sizes.lbs_superblock == 0) {
++		sb->s_security = NULL;
++		return 0;
++	}
++
++	sb->s_security = kzalloc(blob_sizes.lbs_superblock, GFP_KERNEL);
++	if (sb->s_security == NULL)
++		return -ENOMEM;
++	return 0;
++}
++
+ /*
+  * Hook list operation macros.
+  *
+@@ -230,6 +775,24 @@ EXPORT_SYMBOL(unregister_lsm_notifier);
+ 	RC;							\
+ })
+ 
++#define call_one_void_hook(FUNC, ...) ({			\
++	struct lsm_one_hooks *LOH = current_cred()->security;	\
++	if (LOH->FUNC.FUNC)					\
++		LOH->FUNC.FUNC(__VA_ARGS__);			\
++	else if (LOH->lsm == NULL && lsm_base_one.FUNC.FUNC)	\
++		lsm_base_one.FUNC.FUNC(__VA_ARGS__);		\
++})
++
++#define call_one_int_hook(FUNC, IRC, ...) ({			\
++	int RC = IRC;						\
++	struct lsm_one_hooks *LOH = current_cred()->security;	\
++	if (LOH->FUNC.FUNC)					\
++		RC = LOH->FUNC.FUNC(__VA_ARGS__);		\
++	else if (LOH->lsm == NULL && lsm_base_one.FUNC.FUNC)	\
++		RC = lsm_base_one.FUNC.FUNC(__VA_ARGS__);	\
++	RC;							\
++})
++
+ /* Security operations */
+ 
+ int security_binder_set_context_mgr(struct task_struct *mgr)
+@@ -283,12 +846,16 @@ int security_capset(struct cred *new, const struct cred *old,
+ 				effective, inheritable, permitted);
+ }
+ 
+-int security_capable(const struct cred *cred,
+-		     struct user_namespace *ns,
+-		     int cap,
+-		     unsigned int opts)
++int security_capable(const struct cred *cred, struct user_namespace *ns,
++		     int cap)
+ {
+-	return call_int_hook(capable, 0, cred, ns, cap, opts);
++	return call_int_hook(capable, 0, cred, ns, cap, SECURITY_CAP_AUDIT);
++}
++
++int security_capable_noaudit(const struct cred *cred, struct user_namespace *ns,
++			     int cap)
++{
++	return call_int_hook(capable, 0, cred, ns, cap, SECURITY_CAP_NOAUDIT);
+ }
+ 
+ int security_quotactl(int cmds, int type, int id, struct super_block *sb)
+@@ -361,12 +928,21 @@ void security_bprm_committed_creds(struct linux_binprm *bprm)
+ 
+ int security_sb_alloc(struct super_block *sb)
+ {
+-	return call_int_hook(sb_alloc_security, 0, sb);
++	int rc = lsm_superblock_alloc(sb);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(sb_alloc_security, 0, sb);
++	if (unlikely(rc))
++		security_sb_free(sb);
++	return rc;
+ }
+ 
+ void security_sb_free(struct super_block *sb)
+ {
+ 	call_void_hook(sb_free_security, sb);
++	kfree(sb->s_security);
++	sb->s_security = NULL;
+ }
+ 
+ int security_sb_copy_data(char *orig, char *copy)
+@@ -416,9 +992,17 @@ int security_sb_set_mnt_opts(struct super_block *sb,
+ 				unsigned long kern_flags,
+ 				unsigned long *set_kern_flags)
+ {
+-	return call_int_hook(sb_set_mnt_opts,
+-				opts->num_mnt_opts ? -EOPNOTSUPP : 0, sb,
+-				opts, kern_flags, set_kern_flags);
++	int nobody = 0;
++
++	/*
++	 * Additional security modules that use mount options
++	 * need to be added here.
++	 */
++	if (security_num_mnt_opts(opts) > 0)
++		nobody = -EOPNOTSUPP;
++
++	return call_int_hook(sb_set_mnt_opts, nobody, sb, opts, kern_flags,
++				set_kern_flags);
+ }
+ EXPORT_SYMBOL(security_sb_set_mnt_opts);
+ 
+@@ -440,22 +1024,48 @@ EXPORT_SYMBOL(security_sb_parse_opts_str);
+ 
+ int security_inode_alloc(struct inode *inode)
+ {
+-	inode->i_security = NULL;
+-	return call_int_hook(inode_alloc_security, 0, inode);
++	int rc = lsm_inode_alloc(inode);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(inode_alloc_security, 0, inode);
++	if (unlikely(rc))
++		security_inode_free(inode);
++	return rc;
++}
++
++static void inode_free_by_rcu(struct rcu_head *head)
++{
++	/*
++	 * The rcu head is at the start of the inode blob
++	 */
++	kmem_cache_free(lsm_inode_cache, head);
+ }
+ 
+ void security_inode_free(struct inode *inode)
+ {
+ 	integrity_inode_free(inode);
+ 	call_void_hook(inode_free_security, inode);
++	/*
++	 * The inode may still be referenced in a path walk and
++	 * a call to security_inode_permission() can be made
++	 * after inode_free_security() is called. Ideally, the VFS
++	 * wouldn't do this, but fixing that is a much harder
++	 * job. For now, simply free the i_security via RCU, and
++	 * leave the current inode->i_security pointer intact.
++	 * The inode will be freed after the RCU grace period too.
++	 */
++	if (inode->i_security)
++		call_rcu((struct rcu_head *)inode->i_security,
++				inode_free_by_rcu);
+ }
+ 
+ int security_dentry_init_security(struct dentry *dentry, int mode,
+-					const struct qstr *name, void **ctx,
+-					u32 *ctxlen)
++					const struct qstr *name,
++					struct lsm_context *cp)
+ {
+ 	return call_int_hook(dentry_init_security, -EOPNOTSUPP, dentry, mode,
+-				name, ctx, ctxlen);
++			     name, cp);
+ }
+ EXPORT_SYMBOL(security_dentry_init_security);
+ 
+@@ -472,9 +1082,10 @@ int security_inode_init_security(struct inode *inode, struct inode *dir,
+ 				 const struct qstr *qstr,
+ 				 const initxattrs initxattrs, void *fs_data)
+ {
+-	struct xattr new_xattrs[MAX_LSM_EVM_XATTR + 1];
+-	struct xattr *lsm_xattr, *evm_xattr, *xattr;
+-	int ret;
++	struct security_hook_list *p;
++	struct xattr *repo;
++	int rc;
++	int i;
+ 
+ 	if (unlikely(IS_PRIVATE(inode)))
+ 		return 0;
+@@ -482,24 +1093,33 @@ int security_inode_init_security(struct inode *inode, struct inode *dir,
+ 	if (!initxattrs)
+ 		return call_int_hook(inode_init_security, -EOPNOTSUPP, inode,
+ 				     dir, qstr, NULL, NULL, NULL);
+-	memset(new_xattrs, 0, sizeof(new_xattrs));
+-	lsm_xattr = new_xattrs;
+-	ret = call_int_hook(inode_init_security, -EOPNOTSUPP, inode, dir, qstr,
+-						&lsm_xattr->name,
+-						&lsm_xattr->value,
+-						&lsm_xattr->value_len);
+-	if (ret)
+-		goto out;
+ 
+-	evm_xattr = lsm_xattr + 1;
+-	ret = evm_inode_init_security(inode, lsm_xattr, evm_xattr);
+-	if (ret)
+-		goto out;
+-	ret = initxattrs(inode, new_xattrs, fs_data);
++	repo = kzalloc((LSM_COUNT * 2) * sizeof(*repo), GFP_NOFS);
++	if (repo == NULL)
++		return -ENOMEM;
++
++	i = 0;
++	rc = -EOPNOTSUPP;
++	hlist_for_each_entry(p, &security_hook_heads.inode_init_security,
++			     list) {
++		rc = p->hook.inode_init_security(inode, dir, qstr,
++						 &repo[i].name, &repo[i].value,
++						 &repo[i].value_len);
++		if (rc)
++			goto out;
++
++		rc = evm_inode_init_security(inode, &repo[i], &repo[i + 1]);
++		if (rc)
++			goto out;
++
++		i += 2;
++	}
++	rc = initxattrs(inode, repo, fs_data);
+ out:
+-	for (xattr = new_xattrs; xattr->value != NULL; xattr++)
+-		kfree(xattr->value);
+-	return (ret == -EOPNOTSUPP) ? 0 : ret;
++	for (i-- ; i >= 0; i--)
++		kfree(repo[i].value);
++	kfree(repo);
++	return (rc == -EOPNOTSUPP) ? 0 : rc;
+ }
+ EXPORT_SYMBOL(security_inode_init_security);
+ 
+@@ -603,7 +1223,6 @@ int security_path_chown(const struct path *path, kuid_t uid, kgid_t gid)
+ 		return 0;
+ 	return call_int_hook(path_chown, 0, path, uid, gid);
+ }
+-EXPORT_SYMBOL(security_path_chown);
+ 
+ int security_path_chroot(const struct path *path)
+ {
+@@ -728,24 +1347,24 @@ int security_inode_getattr(const struct path *path)
+ int security_inode_setxattr(struct dentry *dentry, const char *name,
+ 			    const void *value, size_t size, int flags)
+ {
+-	int ret;
++	struct security_hook_list *hp;
++	int rc = -ENOSYS;
+ 
+ 	if (unlikely(IS_PRIVATE(d_backing_inode(dentry))))
+ 		return 0;
+-	/*
+-	 * SELinux and Smack integrate the cap call,
+-	 * so assume that all LSMs supplying this call do so.
+-	 */
+-	ret = call_int_hook(inode_setxattr, 1, dentry, name, value, size,
+-				flags);
+ 
+-	if (ret == 1)
+-		ret = cap_inode_setxattr(dentry, name, value, size, flags);
+-	if (ret)
+-		return ret;
+-	ret = ima_inode_setxattr(dentry, name, value, size);
+-	if (ret)
+-		return ret;
++	hlist_for_each_entry(hp, &security_hook_heads.inode_setxattr, list) {
++		rc = hp->hook.inode_setxattr(dentry, name, value, size, flags);
++		if (rc != -ENOSYS)
++			break;
++	}
++	if (rc == -ENOSYS)
++		rc = cap_inode_setxattr(dentry, name, value, size, flags);
++	if (rc)
++		return rc;
++	rc = ima_inode_setxattr(dentry, name, value, size);
++	if (rc)
++		return rc;
+ 	return evm_inode_setxattr(dentry, name, value, size);
+ }
+ 
+@@ -848,9 +1467,10 @@ int security_inode_listsecurity(struct inode *inode, char *buffer, size_t buffer
+ }
+ EXPORT_SYMBOL(security_inode_listsecurity);
+ 
+-void security_inode_getsecid(struct inode *inode, u32 *secid)
++void security_inode_getsecid(struct inode *inode, struct lsm_export *l)
+ {
+-	call_void_hook(inode_getsecid, inode, secid);
++	lsm_export_init(l);
++	call_void_hook(inode_getsecid, inode, l);
+ }
+ 
+ int security_inode_copy_up(struct dentry *src, struct cred **new)
+@@ -878,12 +1498,27 @@ int security_file_permission(struct file *file, int mask)
+ 
+ int security_file_alloc(struct file *file)
+ {
+-	return call_int_hook(file_alloc_security, 0, file);
++	int rc = lsm_file_alloc(file);
++
++	if (rc)
++		return rc;
++	rc = call_int_hook(file_alloc_security, 0, file);
++	if (unlikely(rc))
++		security_file_free(file);
++	return rc;
+ }
+ 
+ void security_file_free(struct file *file)
+ {
++	void *blob;
++
+ 	call_void_hook(file_free_security, file);
++
++	blob = file->f_security;
++	if (blob) {
++		file->f_security = NULL;
++		kmem_cache_free(lsm_file_cache, blob);
++	}
+ }
+ 
+ int security_file_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+@@ -985,51 +1620,93 @@ int security_file_open(struct file *file)
+ 
+ int security_task_alloc(struct task_struct *task, unsigned long clone_flags)
+ {
+-	return call_int_hook(task_alloc, 0, task, clone_flags);
++	int rc = lsm_task_alloc(task);
++
++	if (rc)
++		return rc;
++	rc = call_int_hook(task_alloc, 0, task, clone_flags);
++	if (unlikely(rc))
++		security_task_free(task);
++	return rc;
+ }
+ 
+ void security_task_free(struct task_struct *task)
+ {
+ 	call_void_hook(task_free, task);
++
++	kfree(task->security);
++	task->security = NULL;
+ }
+ 
+ int security_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+ {
+-	return call_int_hook(cred_alloc_blank, 0, cred, gfp);
++	int rc = lsm_cred_alloc(cred, gfp);
++
++	if (rc)
++		return rc;
++
++	rc = call_int_hook(cred_alloc_blank, 0, cred, gfp);
++	if (unlikely(rc))
++		security_cred_free(cred);
++	return rc;
+ }
+ 
+ void security_cred_free(struct cred *cred)
+ {
+-	/*
+-	 * There is a failure case in prepare_creds() that
+-	 * may result in a call here with ->security being NULL.
+-	 */
+-	if (unlikely(cred->security == NULL))
+-		return;
++	struct lsm_one_hooks *loh = cred->security;
+ 
+ 	call_void_hook(cred_free, cred);
++
++	kfree(loh->lsm);
++	kfree(cred->security);
++	cred->security = NULL;
++}
++
++static int copy_loh(struct lsm_one_hooks *new, struct lsm_one_hooks *old,
++		    gfp_t gfp)
++{
++	*new = *old;
++	if (old->lsm) {
++		new->lsm = kstrdup(old->lsm, gfp);
++		if (unlikely(new->lsm == NULL))
++			return -ENOMEM;
++	}
++	return 0;
+ }
+ 
+ int security_prepare_creds(struct cred *new, const struct cred *old, gfp_t gfp)
+ {
+-	return call_int_hook(cred_prepare, 0, new, old, gfp);
++	int rc = lsm_cred_alloc(new, gfp);
++
++	if (unlikely(rc))
++		return rc;
++
++	rc = call_int_hook(cred_prepare, 0, new, old, gfp);
++	if (!unlikely(rc))
++		rc = copy_loh(new->security, old->security, gfp);
++
++	if (unlikely(rc))
++		security_cred_free(new);
++
++	return rc;
+ }
+ 
+ void security_transfer_creds(struct cred *new, const struct cred *old)
+ {
+ 	call_void_hook(cred_transfer, new, old);
++	WARN_ON(copy_loh(new->security, old->security, GFP_KERNEL));
+ }
+ 
+-void security_cred_getsecid(const struct cred *c, u32 *secid)
++void security_cred_getsecid(const struct cred *c, struct lsm_export *l)
+ {
+-	*secid = 0;
+-	call_void_hook(cred_getsecid, c, secid);
++	lsm_export_init(l);
++	call_void_hook(cred_getsecid, c, l);
+ }
+ EXPORT_SYMBOL(security_cred_getsecid);
+ 
+-int security_kernel_act_as(struct cred *new, u32 secid)
++int security_kernel_act_as(struct cred *new, struct lsm_export *l)
+ {
+-	return call_int_hook(kernel_act_as, 0, new, secid);
++	return call_int_hook(kernel_act_as, 0, new, l);
+ }
+ 
+ int security_kernel_create_files_as(struct cred *new, struct inode *inode)
+@@ -1102,10 +1779,10 @@ int security_task_getsid(struct task_struct *p)
+ 	return call_int_hook(task_getsid, 0, p);
+ }
+ 
+-void security_task_getsecid(struct task_struct *p, u32 *secid)
++void security_task_getsecid(struct task_struct *p, struct lsm_export *l)
+ {
+-	*secid = 0;
+-	call_void_hook(task_getsecid, p, secid);
++	lsm_export_init(l);
++	call_void_hook(task_getsecid, p, l);
+ }
+ EXPORT_SYMBOL(security_task_getsecid);
+ 
+@@ -1157,11 +1834,6 @@ int security_task_kill(struct task_struct *p, struct siginfo *info,
+ 	return call_int_hook(task_kill, 0, p, info, sig, cred);
+ }
+ 
+-void security_task_exit(struct task_struct *p)
+-{
+-	call_void_hook(task_exit, p);
+-}
+-
+ int security_task_prctl(int option, unsigned long arg2, unsigned long arg3,
+ 			 unsigned long arg4, unsigned long arg5)
+ {
+@@ -1190,30 +1862,48 @@ int security_ipc_permission(struct kern_ipc_perm *ipcp, short flag)
+ 	return call_int_hook(ipc_permission, 0, ipcp, flag);
+ }
+ 
+-void security_ipc_getsecid(struct kern_ipc_perm *ipcp, u32 *secid)
++void security_ipc_getsecid(struct kern_ipc_perm *ipcp, struct lsm_export *l)
+ {
+-	*secid = 0;
+-	call_void_hook(ipc_getsecid, ipcp, secid);
++	lsm_export_init(l);
++	call_void_hook(ipc_getsecid, ipcp, l);
+ }
+ 
+ int security_msg_msg_alloc(struct msg_msg *msg)
+ {
+-	return call_int_hook(msg_msg_alloc_security, 0, msg);
++	int rc = lsm_msg_msg_alloc(msg);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(msg_msg_alloc_security, 0, msg);
++	if (unlikely(rc))
++		security_msg_msg_free(msg);
++	return rc;
+ }
+ 
+ void security_msg_msg_free(struct msg_msg *msg)
+ {
+ 	call_void_hook(msg_msg_free_security, msg);
++	kfree(msg->security);
++	msg->security = NULL;
+ }
+ 
+ int security_msg_queue_alloc(struct kern_ipc_perm *msq)
+ {
+-	return call_int_hook(msg_queue_alloc_security, 0, msq);
++	int rc = lsm_ipc_alloc(msq);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(msg_queue_alloc_security, 0, msq);
++	if (unlikely(rc))
++		security_msg_queue_free(msq);
++	return rc;
+ }
+ 
+ void security_msg_queue_free(struct kern_ipc_perm *msq)
+ {
+ 	call_void_hook(msg_queue_free_security, msq);
++	kfree(msq->security);
++	msq->security = NULL;
+ }
+ 
+ int security_msg_queue_associate(struct kern_ipc_perm *msq, int msqflg)
+@@ -1240,12 +1930,21 @@ int security_msg_queue_msgrcv(struct kern_ipc_perm *msq, struct msg_msg *msg,
+ 
+ int security_shm_alloc(struct kern_ipc_perm *shp)
+ {
+-	return call_int_hook(shm_alloc_security, 0, shp);
++	int rc = lsm_ipc_alloc(shp);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(shm_alloc_security, 0, shp);
++	if (unlikely(rc))
++		security_shm_free(shp);
++	return rc;
+ }
+ 
+ void security_shm_free(struct kern_ipc_perm *shp)
+ {
+ 	call_void_hook(shm_free_security, shp);
++	kfree(shp->security);
++	shp->security = NULL;
+ }
+ 
+ int security_shm_associate(struct kern_ipc_perm *shp, int shmflg)
+@@ -1265,12 +1964,21 @@ int security_shm_shmat(struct kern_ipc_perm *shp, char __user *shmaddr, int shmf
+ 
+ int security_sem_alloc(struct kern_ipc_perm *sma)
+ {
+-	return call_int_hook(sem_alloc_security, 0, sma);
++	int rc = lsm_ipc_alloc(sma);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(sem_alloc_security, 0, sma);
++	if (unlikely(rc))
++		security_sem_free(sma);
++	return rc;
+ }
+ 
+ void security_sem_free(struct kern_ipc_perm *sma)
+ {
+ 	call_void_hook(sem_free_security, sma);
++	kfree(sma->security);
++	sma->security = NULL;
+ }
+ 
+ int security_sem_associate(struct kern_ipc_perm *sma, int semflg)
+@@ -1297,14 +2005,126 @@ void security_d_instantiate(struct dentry *dentry, struct inode *inode)
+ }
+ EXPORT_SYMBOL(security_d_instantiate);
+ 
+-int security_getprocattr(struct task_struct *p, char *name, char **value)
++int security_getprocattr(struct task_struct *p, const char *lsm, char *name,
++				char **value)
+ {
+-	return call_int_hook(getprocattr, -EINVAL, p, name, value);
++	struct security_hook_list *hp;
++	struct lsm_one_hooks *loh = current_cred()->security;
++	char *s;
++
++	if (!strcmp(name, "display")) {
++		if (loh->lsm)
++			s = loh->lsm;
++		else if (lsm_base_one.lsm)
++			s = lsm_base_one.lsm;
++		else
++			return -EINVAL;
++
++		*value = kstrdup(s, GFP_KERNEL);
++		if (*value)
++			return strlen(s);
++		return -ENOMEM;
++	}
++
++	hlist_for_each_entry(hp, &security_hook_heads.getprocattr, list) {
++		if (lsm != NULL && strcmp(lsm, hp->lsm))
++			continue;
++		if (lsm == NULL && loh->lsm && strcmp(loh->lsm, hp->lsm))
++			continue;
++		return hp->hook.getprocattr(p, name, value);
++	}
++	return -EINVAL;
+ }
+ 
+-int security_setprocattr(const char *name, void *value, size_t size)
++/*
++ * The use of the secid_to_secctx memeber of the union is
++ * arbitrary. Any member would work.
++ */
++static bool lsm_add_one(union security_list_options *hook,
++			struct hlist_head *head, char *lsm, size_t size,
++			bool was)
+ {
+-	return call_int_hook(setprocattr, -EINVAL, name, value, size);
++	struct security_hook_list *hp;
++
++	hlist_for_each_entry(hp, head, list) {
++		if (size >= strlen(hp->lsm) && !strncmp(lsm, hp->lsm, size)) {
++			hook->secid_to_secctx = hp->hook.secid_to_secctx;
++			return true;
++		}
++	}
++	hook->secid_to_secctx = NULL;
++	return was;
++}
++
++int security_setprocattr(const char *lsm, const char *name, void *value,
++			 size_t size)
++{
++	struct security_hook_list *hp;
++	struct lsm_one_hooks *loh = current_cred()->security;
++	char *s;
++
++	/*
++	 * End the passed name at a newline.
++	 */
++	s = strnchr(value, size, '\n');
++	if (s)
++		*s = '\0';
++
++	if (!strcmp(name, "display")) {
++		struct lsm_one_hooks o;
++		bool found = false;
++
++		if (size == 0 || size >= 100)
++			return -EINVAL;
++
++		found = lsm_add_one(&o.secid_to_secctx,
++				    &security_hook_heads.secid_to_secctx,
++				    value, size, found);
++		found = lsm_add_one(&o.secctx_to_secid,
++				    &security_hook_heads.secctx_to_secid,
++				    value, size, found);
++		found = lsm_add_one(&o.socket_getpeersec_stream,
++				 &security_hook_heads.socket_getpeersec_stream,
++				    value, size, found);
++		found = lsm_add_one(&o.secmark_relabel_packet,
++				    &security_hook_heads.secmark_relabel_packet,
++				    value, size, found);
++		found = lsm_add_one(&o.secmark_refcount_inc,
++				    &security_hook_heads.secmark_refcount_inc,
++				    value, size, found);
++		found = lsm_add_one(&o.secmark_refcount_dec,
++				    &security_hook_heads.secmark_refcount_dec,
++				    value, size, found);
++
++		if (!found)
++			return -EINVAL;
++
++		/*
++		 * The named lsm is active and supplies one or more
++		 * of the relevant hooks. Switch to it.
++		 */
++		s = kmemdup(value, size + 1, GFP_KERNEL);
++		if (s == NULL)
++			return -ENOMEM;
++		s[size] = '\0';
++
++		if (loh->lsm)
++			kfree(loh->lsm);
++
++		*loh = o;
++		loh->lsm = s;
++
++		return size;
++	}
++
++	hlist_for_each_entry(hp, &security_hook_heads.setprocattr, list) {
++		if (lsm != NULL && strcmp(lsm, hp->lsm))
++			continue;
++		if (lsm == NULL && loh->lsm && strcmp(loh->lsm, hp->lsm))
++			continue;
++		return hp->hook.setprocattr(name, value, size);
++	}
++	return -EINVAL;
+ }
+ 
+ int security_netlink_send(struct sock *sk, struct sk_buff *skb)
+@@ -1318,23 +2138,25 @@ int security_ismaclabel(const char *name)
+ }
+ EXPORT_SYMBOL(security_ismaclabel);
+ 
+-int security_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
++int security_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp)
+ {
+-	return call_int_hook(secid_to_secctx, -EOPNOTSUPP, secid, secdata,
+-				seclen);
++	return call_one_int_hook(secid_to_secctx, -EOPNOTSUPP, l, cp);
+ }
+ EXPORT_SYMBOL(security_secid_to_secctx);
+ 
+-int security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
++int security_secctx_to_secid(struct lsm_context *cp, struct lsm_export *l)
+ {
+-	*secid = 0;
+-	return call_int_hook(secctx_to_secid, 0, secdata, seclen, secid);
++	lsm_export_init(l);
++	return call_one_int_hook(secctx_to_secid, 0, cp, l);
+ }
+ EXPORT_SYMBOL(security_secctx_to_secid);
+ 
+-void security_release_secctx(char *secdata, u32 seclen)
++void security_release_secctx(struct lsm_context *cp)
+ {
+-	call_void_hook(release_secctx, secdata, seclen);
++	if (WARN_ON(cp->release == NULL))
++		return;
++	cp->release(cp);
++	lsm_context_init(cp);
+ }
+ EXPORT_SYMBOL(security_release_secctx);
+ 
+@@ -1344,21 +2166,115 @@ void security_inode_invalidate_secctx(struct inode *inode)
+ }
+ EXPORT_SYMBOL(security_inode_invalidate_secctx);
+ 
+-int security_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen)
++int security_inode_notifysecctx(struct inode *inode, struct lsm_context *cp)
+ {
+-	return call_int_hook(inode_notifysecctx, 0, inode, ctx, ctxlen);
++	return call_int_hook(inode_notifysecctx, 0, inode, cp);
+ }
+ EXPORT_SYMBOL(security_inode_notifysecctx);
+ 
+-int security_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen)
++/*
++ * The inode_[gs]etsecctx functions need to proved a context
++ * for multiple security modules. If there is more than one
++ * LSM supplying hooks the format will be
++ *	lsm1='value',lsm2='value'[,lsmN='value']...
++ */
++static void lsm_release_secctx(struct lsm_context *cp)
++{
++	kfree(cp->context);
++}
++
++int security_inode_setsecctx(struct dentry *dentry, struct lsm_context *cp)
+ {
+-	return call_int_hook(inode_setsecctx, 0, dentry, ctx, ctxlen);
++	struct security_hook_list *hp;
++	struct lsm_context lc;
++	char *full;
++	char *ctx;
++	char *quote;
++	int rc = 0;
++
++	if (lsm_inode_secctx_count <= 1)
++		return call_int_hook(inode_setsecctx, 0, dentry, cp);
++
++	full = kstrndup(cp->context, cp->len, GFP_KERNEL);
++	if (full == NULL)
++		return -ENOMEM;
++
++	ctx = full;
++	hlist_for_each_entry(hp, &security_hook_heads.inode_setsecctx, list) {
++		if (strncmp(ctx, hp->lsm, strlen(hp->lsm))) {
++			WARN_ONCE(1, "security_inode_setsecctx form1 error\n");
++			rc = -EINVAL;
++			break;
++		}
++		ctx += strlen(hp->lsm);
++		if (ctx[0] != '=' || ctx[1] != '\'') {
++			WARN_ONCE(1, "security_inode_setsecctx form2 error\n");
++			rc = -EINVAL;
++			break;
++		}
++		ctx += 2;
++		quote = strnchr(ctx, cp->len, '\'');
++		if (quote == NULL) {
++			WARN_ONCE(1, "security_inode_setsecctx form3 error\n");
++			rc = -EINVAL;
++			break;
++		}
++		quote[0] = '\0';
++		if (quote[1] != ',' && quote[1] != '\0') {
++			WARN_ONCE(1, "security_inode_setsecctx form4 error\n");
++			rc = -EINVAL;
++			break;
++		}
++		lc.context = ctx;
++		lc.len = strlen(ctx);
++
++		ctx = quote + 2;
++
++		rc = hp->hook.inode_setsecctx(dentry, &lc);
++		if (rc)
++			break;
++	}
++
++	kfree(full);
++	return rc;
+ }
+ EXPORT_SYMBOL(security_inode_setsecctx);
+ 
+-int security_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen)
++int security_inode_getsecctx(struct inode *inode, struct lsm_context *cp)
+ {
+-	return call_int_hook(inode_getsecctx, -EOPNOTSUPP, inode, ctx, ctxlen);
++	struct security_hook_list *hp;
++	struct lsm_context lc;
++	char *final = NULL;
++	char *tp;
++	int rc;
++
++	if (lsm_inode_secctx_count <= 1)
++		return call_int_hook(inode_getsecctx, -EOPNOTSUPP, inode, cp);
++
++	hlist_for_each_entry(hp, &security_hook_heads.inode_getsecctx, list) {
++		rc = hp->hook.inode_getsecctx(inode, &lc);
++		if (rc) {
++			kfree(final);
++			return rc;
++		}
++		if (final) {
++			tp = kasprintf(GFP_KERNEL, "%s,%s='%s'", final,
++				       hp->lsm, lc.context);
++			kfree(final);
++		} else
++			tp = kasprintf(GFP_KERNEL, "%s='%s'", hp->lsm,
++				       lc.context);
++		security_release_secctx(&lc);
++		if (tp == NULL) {
++			kfree(final);
++			return -ENOMEM;
++		}
++		final = tp;
++	}
++	cp->context = final;
++	cp->len = strlen(final);
++	cp->release = lsm_release_secctx;
++	return 0;
+ }
+ EXPORT_SYMBOL(security_inode_getsecctx);
+ 
+@@ -1459,25 +2375,36 @@ EXPORT_SYMBOL(security_sock_rcv_skb);
+ int security_socket_getpeersec_stream(struct socket *sock, char __user *optval,
+ 				      int __user *optlen, unsigned len)
+ {
+-	return call_int_hook(socket_getpeersec_stream, -ENOPROTOOPT, sock,
++	return call_one_int_hook(socket_getpeersec_stream, -ENOPROTOOPT, sock,
+ 				optval, optlen, len);
+ }
+ 
+-int security_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb, u32 *secid)
++int security_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb,
++				     struct lsm_export *l)
+ {
+-	return call_int_hook(socket_getpeersec_dgram, -ENOPROTOOPT, sock,
+-			     skb, secid);
++	lsm_export_init(l);
++	return call_int_hook(socket_getpeersec_dgram, -ENOPROTOOPT, sock, skb,
++			     l);
+ }
+ EXPORT_SYMBOL(security_socket_getpeersec_dgram);
+ 
+ int security_sk_alloc(struct sock *sk, int family, gfp_t priority)
+ {
+-	return call_int_hook(sk_alloc_security, 0, sk, family, priority);
++	int rc = lsm_sock_alloc(sk, priority);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(sk_alloc_security, 0, sk, family, priority);
++	if (unlikely(rc))
++		security_sk_free(sk);
++	return rc;
+ }
+ 
+ void security_sk_free(struct sock *sk)
+ {
+ 	call_void_hook(sk_free_security, sk);
++	kfree(sk->sk_security);
++	sk->sk_security = NULL;
+ }
+ 
+ void security_sk_clone(const struct sock *sk, struct sock *newsk)
+@@ -1526,19 +2453,19 @@ EXPORT_SYMBOL(security_inet_conn_established);
+ 
+ int security_secmark_relabel_packet(u32 secid)
+ {
+-	return call_int_hook(secmark_relabel_packet, 0, secid);
++	return call_one_int_hook(secmark_relabel_packet, 0, secid);
+ }
+ EXPORT_SYMBOL(security_secmark_relabel_packet);
+ 
+ void security_secmark_refcount_inc(void)
+ {
+-	call_void_hook(secmark_refcount_inc);
++	call_one_void_hook(secmark_refcount_inc);
+ }
+ EXPORT_SYMBOL(security_secmark_refcount_inc);
+ 
+ void security_secmark_refcount_dec(void)
+ {
+-	call_void_hook(secmark_refcount_dec);
++	call_one_void_hook(secmark_refcount_dec);
+ }
+ EXPORT_SYMBOL(security_secmark_refcount_dec);
+ 
+@@ -1729,12 +2656,21 @@ EXPORT_SYMBOL(security_skb_classify_flow);
+ int security_key_alloc(struct key *key, const struct cred *cred,
+ 		       unsigned long flags)
+ {
+-	return call_int_hook(key_alloc, 0, key, cred, flags);
++	int rc = lsm_key_alloc(key);
++
++	if (unlikely(rc))
++		return rc;
++	rc = call_int_hook(key_alloc, 0, key, cred, flags);
++	if (unlikely(rc))
++		security_key_free(key);
++	return rc;
+ }
+ 
+ void security_key_free(struct key *key)
+ {
+ 	call_void_hook(key_free, key);
++	kfree(key->security);
++	key->security = NULL;
+ }
+ 
+ int security_key_permission(key_ref_t key_ref,
+@@ -1768,11 +2704,10 @@ void security_audit_rule_free(void *lsmrule)
+ 	call_void_hook(audit_rule_free, lsmrule);
+ }
+ 
+-int security_audit_rule_match(u32 secid, u32 field, u32 op, void *lsmrule,
+-			      struct audit_context *actx)
++int security_audit_rule_match(struct lsm_export *l, u32 field, u32 op,
++			      void *lsmrule, struct audit_context *actx)
+ {
+-	return call_int_hook(audit_rule_match, 0, secid, field, op, lsmrule,
+-				actx);
++	return call_int_hook(audit_rule_match, 0, l, field, op, lsmrule, actx);
+ }
+ #endif /* CONFIG_AUDIT */
+ 
+diff --git a/security/selinux/Kconfig b/security/selinux/Kconfig
+index d5893b58570f..55f032f1fc2d 100644
+--- a/security/selinux/Kconfig
++++ b/security/selinux/Kconfig
+@@ -22,21 +22,6 @@ config SECURITY_SELINUX_BOOTPARAM
+ 
+ 	  If you are unsure how to answer this question, answer N.
+ 
+-config SECURITY_SELINUX_BOOTPARAM_VALUE
+-	int "NSA SELinux boot parameter default value"
+-	depends on SECURITY_SELINUX_BOOTPARAM
+-	range 0 1
+-	default 1
+-	help
+-	  This option sets the default value for the kernel parameter
+-	  'selinux', which allows SELinux to be disabled at boot.  If this
+-	  option is set to 0 (zero), the SELinux kernel parameter will
+-	  default to 0, disabling SELinux at bootup.  If this option is
+-	  set to 1 (one), the SELinux kernel parameter will default to 1,
+-	  enabling SELinux at bootup.
+-
+-	  If you are unsure how to answer this question, answer 1.
+-
+ config SECURITY_SELINUX_DISABLE
+ 	bool "NSA SELinux runtime disable"
+ 	depends on SECURITY_SELINUX
+@@ -71,16 +56,6 @@ config SECURITY_SELINUX_DEVELOP
+ 	  can interactively toggle the kernel between enforcing mode and
+ 	  permissive mode (if permitted by the policy) via /selinux/enforce.
+ 
+-config SECURITY_SELINUX_PERMISSIVE_DONTAUDIT
+-	bool "NSA SELinux don't audit permissive"
+-	depends on SECURITY_SELINUX
+-	default n
+-	help
+-	  This prevents logging when permissive=1.  If unsure, say N.  With
+-	  this option enabled, any avc logs that would occur on a permissive
+-	  domain won't be logged.  This can prevent a significant amount of
+-	  logspam.
+-
+ config SECURITY_SELINUX_AVC_STATS
+ 	bool "NSA SELinux AVC Statistics"
+ 	depends on SECURITY_SELINUX
+diff --git a/security/selinux/Makefile b/security/selinux/Makefile
+index c7161f8792b2..ccf950409384 100644
+--- a/security/selinux/Makefile
++++ b/security/selinux/Makefile
+@@ -6,7 +6,7 @@
+ obj-$(CONFIG_SECURITY_SELINUX) := selinux.o
+ 
+ selinux-y := avc.o hooks.o selinuxfs.o netlink.o nlmsgtab.o netif.o \
+-	     netnode.o netport.o ibpkey.o exports.o \
++	     netnode.o netport.o ibpkey.o \
+ 	     ss/ebitmap.o ss/hashtab.o ss/symtab.o ss/sidtab.o ss/avtab.o \
+ 	     ss/policydb.o ss/services.o ss/conditional.o ss/mls.o ss/status.o
+ 
+diff --git a/security/selinux/avc.c b/security/selinux/avc.c
+index de5fe7e9ea00..635e5c1e3e48 100644
+--- a/security/selinux/avc.c
++++ b/security/selinux/avc.c
+@@ -772,15 +772,6 @@ noinline int slow_avc_audit(struct selinux_state *state,
+ 	struct common_audit_data stack_data;
+ 	struct selinux_audit_data sad;
+ 
+-	/*
+-	 * Avoid logging permissive=1 messages for
+-	 * SECURITY_SELINUX_PERMISSIVE_DONTAUDIT.
+-	 */
+-	if (IS_ENABLED(CONFIG_SECURITY_SELINUX_PERMISSIVE_DONTAUDIT) && denied
+-	    && !result) {
+-		return 0;
+-	}
+-
+ 	if (!a) {
+ 		a = &stack_data;
+ 		a->type = LSM_AUDIT_DATA_NONE;
+@@ -847,7 +838,6 @@ int __init avc_add_callback(int (*callback)(u32 event), u32 events)
+  * @ssid,@tsid,@tclass : identifier of an AVC entry
+  * @seqno : sequence number when decision was made
+  * @xpd: extended_perms_decision to be added to the node
+- * @flags: the AVC_* flags, e.g. AVC_NONBLOCKING, AVC_EXTENDED_PERMS, or 0.
+  *
+  * if a valid AVC entry doesn't exist,this function returns -ENOENT.
+  * if kmalloc() called internal returns NULL, this function returns -ENOMEM.
+@@ -866,23 +856,6 @@ static int avc_update_node(struct selinux_avc *avc,
+ 	struct hlist_head *head;
+ 	spinlock_t *lock;
+ 
+-	/*
+-	 * If we are in a non-blocking code path, e.g. VFS RCU walk,
+-	 * then we must not add permissions to a cache entry
+-	 * because we cannot safely audit the denial.  Otherwise,
+-	 * during the subsequent blocking retry (e.g. VFS ref walk), we
+-	 * will find the permissions already granted in the cache entry
+-	 * and won't audit anything at all, leading to silent denials in
+-	 * permissive mode that only appear when in enforcing mode.
+-	 *
+-	 * See the corresponding handling in slow_avc_audit(), and the
+-	 * logic in selinux_inode_follow_link and selinux_inode_permission
+-	 * for the VFS MAY_NOT_BLOCK flag, which is transliterated into
+-	 * AVC_NONBLOCKING for avc_has_perm_noaudit().
+-	 */
+-	if (flags & AVC_NONBLOCKING)
+-		return 0;
+-
+ 	node = avc_alloc_node(avc);
+ 	if (!node) {
+ 		rc = -ENOMEM;
+@@ -1142,7 +1115,7 @@ int avc_has_extended_perms(struct selinux_state *state,
+  * @tsid: target security identifier
+  * @tclass: target security class
+  * @requested: requested permissions, interpreted based on @tclass
+- * @flags:  AVC_STRICT, AVC_NONBLOCKING, or 0
++ * @flags:  AVC_STRICT or 0
+  * @avd: access vector decisions
+  *
+  * Check the AVC to determine whether the @requested permissions are granted
+@@ -1226,8 +1199,7 @@ int avc_has_perm_flags(struct selinux_state *state,
+ 	struct av_decision avd;
+ 	int rc, rc2;
+ 
+-	rc = avc_has_perm_noaudit(state, ssid, tsid, tclass, requested,
+-				  (flags & MAY_NOT_BLOCK) ? AVC_NONBLOCKING : 0,
++	rc = avc_has_perm_noaudit(state, ssid, tsid, tclass, requested, 0,
+ 				  &avd);
+ 
+ 	rc2 = avc_audit(state, ssid, tsid, tclass, requested, &avd, rc,
+diff --git a/security/selinux/exports.c b/security/selinux/exports.c
+deleted file mode 100644
+index e75dd94e2d2b..000000000000
+--- a/security/selinux/exports.c
++++ /dev/null
+@@ -1,23 +0,0 @@
+-/*
+- * SELinux services exported to the rest of the kernel.
+- *
+- * Author: James Morris <jmorris@redhat.com>
+- *
+- * Copyright (C) 2005 Red Hat, Inc., James Morris <jmorris@redhat.com>
+- * Copyright (C) 2006 Trusted Computer Solutions, Inc. <dgoeddel@trustedcs.com>
+- * Copyright (C) 2006 IBM Corporation, Timothy R. Chavez <tinytim@us.ibm.com>
+- *
+- * This program is free software; you can redistribute it and/or modify
+- * it under the terms of the GNU General Public License version 2,
+- * as published by the Free Software Foundation.
+- */
+-#include <linux/module.h>
+-#include <linux/selinux.h>
+-
+-#include "security.h"
+-
+-bool selinux_is_enabled(void)
+-{
+-	return selinux_enabled;
+-}
+-EXPORT_SYMBOL_GPL(selinux_is_enabled);
+diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
+index 040c843968dc..38b170236db3 100644
+--- a/security/selinux/hooks.c
++++ b/security/selinux/hooks.c
+@@ -79,7 +79,6 @@
+ #include <linux/personality.h>
+ #include <linux/audit.h>
+ #include <linux/string.h>
+-#include <linux/selinux.h>
+ #include <linux/mutex.h>
+ #include <linux/posix-timers.h>
+ #include <linux/syslog.h>
+@@ -120,9 +119,8 @@ __setup("enforcing=", enforcing_setup);
+ #define selinux_enforcing_boot 1
+ #endif
+ 
++int selinux_enabled __lsm_ro_after_init = 1;
+ #ifdef CONFIG_SECURITY_SELINUX_BOOTPARAM
+-int selinux_enabled = CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE;
+-
+ static int __init selinux_enabled_setup(char *str)
+ {
+ 	unsigned long enabled;
+@@ -131,8 +129,6 @@ static int __init selinux_enabled_setup(char *str)
+ 	return 1;
+ }
+ __setup("selinux=", selinux_enabled_setup);
+-#else
+-int selinux_enabled = 1;
+ #endif
+ 
+ static unsigned int selinux_checkreqprot_boot =
+@@ -148,9 +144,6 @@ static int __init checkreqprot_setup(char *str)
+ }
+ __setup("checkreqprot=", checkreqprot_setup);
+ 
+-static struct kmem_cache *sel_inode_cache;
+-static struct kmem_cache *file_security_cache;
+-
+ /**
+  * selinux_secmark_enabled - Check to see if SECMARK is currently enabled
+  *
+@@ -213,12 +206,9 @@ static void cred_init_security(void)
+ 	struct cred *cred = (struct cred *) current->real_cred;
+ 	struct task_security_struct *tsec;
+ 
+-	tsec = kzalloc(sizeof(struct task_security_struct), GFP_KERNEL);
+-	if (!tsec)
+-		panic("SELinux:  Failed to initialize initial task.\n");
+-
++	lsm_early_cred(cred);
++	tsec = selinux_cred(cred);
+ 	tsec->osid = tsec->sid = SECINITSID_KERNEL;
+-	cred->security = tsec;
+ }
+ 
+ /*
+@@ -228,7 +218,7 @@ static inline u32 cred_sid(const struct cred *cred)
+ {
+ 	const struct task_security_struct *tsec;
+ 
+-	tsec = cred->security;
++	tsec = selinux_cred(cred);
+ 	return tsec->sid;
+ }
+ 
+@@ -249,13 +239,9 @@ static inline u32 task_sid(const struct task_struct *task)
+ 
+ static int inode_alloc_security(struct inode *inode)
+ {
+-	struct inode_security_struct *isec;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 	u32 sid = current_sid();
+ 
+-	isec = kmem_cache_zalloc(sel_inode_cache, GFP_NOFS);
+-	if (!isec)
+-		return -ENOMEM;
+-
+ 	spin_lock_init(&isec->lock);
+ 	INIT_LIST_HEAD(&isec->list);
+ 	isec->inode = inode;
+@@ -263,7 +249,6 @@ static int inode_alloc_security(struct inode *inode)
+ 	isec->sclass = SECCLASS_FILE;
+ 	isec->task_sid = sid;
+ 	isec->initialized = LABEL_INVALID;
+-	inode->i_security = isec;
+ 
+ 	return 0;
+ }
+@@ -280,7 +265,7 @@ static int __inode_security_revalidate(struct inode *inode,
+ 				       struct dentry *dentry,
+ 				       bool may_sleep)
+ {
+-	struct inode_security_struct *isec = inode->i_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 
+ 	might_sleep_if(may_sleep);
+ 
+@@ -301,7 +286,7 @@ static int __inode_security_revalidate(struct inode *inode,
+ 
+ static struct inode_security_struct *inode_security_novalidate(struct inode *inode)
+ {
+-	return inode->i_security;
++	return selinux_inode(inode);
+ }
+ 
+ static struct inode_security_struct *inode_security_rcu(struct inode *inode, bool rcu)
+@@ -311,7 +296,7 @@ static struct inode_security_struct *inode_security_rcu(struct inode *inode, boo
+ 	error = __inode_security_revalidate(inode, NULL, !rcu);
+ 	if (error)
+ 		return ERR_PTR(error);
+-	return inode->i_security;
++	return selinux_inode(inode);
+ }
+ 
+ /*
+@@ -320,14 +305,14 @@ static struct inode_security_struct *inode_security_rcu(struct inode *inode, boo
+ static struct inode_security_struct *inode_security(struct inode *inode)
+ {
+ 	__inode_security_revalidate(inode, NULL, true);
+-	return inode->i_security;
++	return selinux_inode(inode);
+ }
+ 
+ static struct inode_security_struct *backing_inode_security_novalidate(struct dentry *dentry)
+ {
+ 	struct inode *inode = d_backing_inode(dentry);
+ 
+-	return inode->i_security;
++	return selinux_inode(inode);
+ }
+ 
+ /*
+@@ -338,22 +323,17 @@ static struct inode_security_struct *backing_inode_security(struct dentry *dentr
+ 	struct inode *inode = d_backing_inode(dentry);
+ 
+ 	__inode_security_revalidate(inode, dentry, true);
+-	return inode->i_security;
+-}
+-
+-static void inode_free_rcu(struct rcu_head *head)
+-{
+-	struct inode_security_struct *isec;
+-
+-	isec = container_of(head, struct inode_security_struct, rcu);
+-	kmem_cache_free(sel_inode_cache, isec);
++	return selinux_inode(inode);
+ }
+ 
+ static void inode_free_security(struct inode *inode)
+ {
+-	struct inode_security_struct *isec = inode->i_security;
+-	struct superblock_security_struct *sbsec = inode->i_sb->s_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
++	struct superblock_security_struct *sbsec;
+ 
++	if (!isec)
++		return;
++	sbsec = selinux_superblock(inode->i_sb);
+ 	/*
+ 	 * As not all inode security structures are in a list, we check for
+ 	 * empty list outside of the lock to make sure that we won't waste
+@@ -369,49 +349,22 @@ static void inode_free_security(struct inode *inode)
+ 		list_del_init(&isec->list);
+ 		spin_unlock(&sbsec->isec_lock);
+ 	}
+-
+-	/*
+-	 * The inode may still be referenced in a path walk and
+-	 * a call to selinux_inode_permission() can be made
+-	 * after inode_free_security() is called. Ideally, the VFS
+-	 * wouldn't do this, but fixing that is a much harder
+-	 * job. For now, simply free the i_security via RCU, and
+-	 * leave the current inode->i_security pointer intact.
+-	 * The inode will be freed after the RCU grace period too.
+-	 */
+-	call_rcu(&isec->rcu, inode_free_rcu);
+ }
+ 
+ static int file_alloc_security(struct file *file)
+ {
+-	struct file_security_struct *fsec;
++	struct file_security_struct *fsec = selinux_file(file);
+ 	u32 sid = current_sid();
+ 
+-	fsec = kmem_cache_zalloc(file_security_cache, GFP_KERNEL);
+-	if (!fsec)
+-		return -ENOMEM;
+-
+ 	fsec->sid = sid;
+ 	fsec->fown_sid = sid;
+-	file->f_security = fsec;
+ 
+ 	return 0;
+ }
+ 
+-static void file_free_security(struct file *file)
+-{
+-	struct file_security_struct *fsec = file->f_security;
+-	file->f_security = NULL;
+-	kmem_cache_free(file_security_cache, fsec);
+-}
+-
+ static int superblock_alloc_security(struct super_block *sb)
+ {
+-	struct superblock_security_struct *sbsec;
+-
+-	sbsec = kzalloc(sizeof(struct superblock_security_struct), GFP_KERNEL);
+-	if (!sbsec)
+-		return -ENOMEM;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
+ 
+ 	mutex_init(&sbsec->lock);
+ 	INIT_LIST_HEAD(&sbsec->isec_head);
+@@ -420,18 +373,10 @@ static int superblock_alloc_security(struct super_block *sb)
+ 	sbsec->sid = SECINITSID_UNLABELED;
+ 	sbsec->def_sid = SECINITSID_FILE;
+ 	sbsec->mntpoint_sid = SECINITSID_UNLABELED;
+-	sb->s_security = sbsec;
+ 
+ 	return 0;
+ }
+ 
+-static void superblock_free_security(struct super_block *sb)
+-{
+-	struct superblock_security_struct *sbsec = sb->s_security;
+-	sb->s_security = NULL;
+-	kfree(sbsec);
+-}
+-
+ static inline int inode_doinit(struct inode *inode)
+ {
+ 	return inode_doinit_with_dentry(inode, NULL);
+@@ -464,7 +409,7 @@ static int may_context_mount_sb_relabel(u32 sid,
+ 			struct superblock_security_struct *sbsec,
+ 			const struct cred *cred)
+ {
+-	const struct task_security_struct *tsec = cred->security;
++	const struct task_security_struct *tsec = selinux_cred(cred);
+ 	int rc;
+ 
+ 	rc = avc_has_perm(&selinux_state,
+@@ -483,7 +428,7 @@ static int may_context_mount_inode_relabel(u32 sid,
+ 			struct superblock_security_struct *sbsec,
+ 			const struct cred *cred)
+ {
+-	const struct task_security_struct *tsec = cred->security;
++	const struct task_security_struct *tsec = selinux_cred(cred);
+ 	int rc;
+ 	rc = avc_has_perm(&selinux_state,
+ 			  tsec->sid, sbsec->sid, SECCLASS_FILESYSTEM,
+@@ -497,10 +442,16 @@ static int may_context_mount_inode_relabel(u32 sid,
+ 	return rc;
+ }
+ 
+-static int selinux_is_genfs_special_handling(struct super_block *sb)
++static int selinux_is_sblabel_mnt(struct super_block *sb)
+ {
+-	/* Special handling. Genfs but also in-core setxattr handler */
+-	return	!strcmp(sb->s_type->name, "sysfs") ||
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
++
++	return sbsec->behavior == SECURITY_FS_USE_XATTR ||
++		sbsec->behavior == SECURITY_FS_USE_TRANS ||
++		sbsec->behavior == SECURITY_FS_USE_TASK ||
++		sbsec->behavior == SECURITY_FS_USE_NATIVE ||
++		/* Special handling. Genfs but also in-core setxattr handler */
++		!strcmp(sb->s_type->name, "sysfs") ||
+ 		!strcmp(sb->s_type->name, "pstore") ||
+ 		!strcmp(sb->s_type->name, "debugfs") ||
+ 		!strcmp(sb->s_type->name, "tracefs") ||
+@@ -510,37 +461,9 @@ static int selinux_is_genfs_special_handling(struct super_block *sb)
+ 		  !strcmp(sb->s_type->name, "cgroup2")));
+ }
+ 
+-static int selinux_is_sblabel_mnt(struct super_block *sb)
+-{
+-	struct superblock_security_struct *sbsec = sb->s_security;
+-
+-	/*
+-	 * IMPORTANT: Double-check logic in this function when adding a new
+-	 * SECURITY_FS_USE_* definition!
+-	 */
+-	BUILD_BUG_ON(SECURITY_FS_USE_MAX != 7);
+-
+-	switch (sbsec->behavior) {
+-	case SECURITY_FS_USE_XATTR:
+-	case SECURITY_FS_USE_TRANS:
+-	case SECURITY_FS_USE_TASK:
+-	case SECURITY_FS_USE_NATIVE:
+-		return 1;
+-
+-	case SECURITY_FS_USE_GENFS:
+-		return selinux_is_genfs_special_handling(sb);
+-
+-	/* Never allow relabeling on context mounts */
+-	case SECURITY_FS_USE_MNTPOINT:
+-	case SECURITY_FS_USE_NONE:
+-	default:
+-		return 0;
+-	}
+-}
+-
+ static int sb_finish_set_opts(struct super_block *sb)
+ {
+-	struct superblock_security_struct *sbsec = sb->s_security;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
+ 	struct dentry *root = sb->s_root;
+ 	struct inode *root_inode = d_backing_inode(root);
+ 	int rc = 0;
+@@ -620,15 +543,16 @@ static int sb_finish_set_opts(struct super_block *sb)
+  * mount options, or whatever.
+  */
+ static int selinux_get_mnt_opts(const struct super_block *sb,
+-				struct security_mnt_opts *opts)
++				struct security_mnt_opts *all_opts)
+ {
+ 	int rc = 0, i;
+-	struct superblock_security_struct *sbsec = sb->s_security;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
++	struct lsm_mnt_opts *opts = &all_opts->selinux;
+ 	char *context = NULL;
+ 	u32 len;
+ 	char tmp;
+ 
+-	security_init_mnt_opts(opts);
++	security_init_mnt_opts(all_opts);
+ 
+ 	if (!(sbsec->flags & SE_SBINITIALIZED))
+ 		return -EINVAL;
+@@ -709,7 +633,7 @@ static int selinux_get_mnt_opts(const struct super_block *sb,
+ 	return 0;
+ 
+ out_free:
+-	security_free_mnt_opts(opts);
++	security_free_mnt_opts(all_opts);
+ 	return rc;
+ }
+ 
+@@ -738,13 +662,14 @@ static int bad_option(struct superblock_security_struct *sbsec, char flag,
+  * labeling information.
+  */
+ static int selinux_set_mnt_opts(struct super_block *sb,
+-				struct security_mnt_opts *opts,
++				struct security_mnt_opts *all_opts,
+ 				unsigned long kern_flags,
+ 				unsigned long *set_kern_flags)
+ {
+ 	const struct cred *cred = current_cred();
++	struct lsm_mnt_opts *opts = &all_opts->selinux;
+ 	int rc = 0, i;
+-	struct superblock_security_struct *sbsec = sb->s_security;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
+ 	const char *name = sb->s_type->name;
+ 	struct dentry *root = sbsec->sb->s_root;
+ 	struct inode_security_struct *root_isec;
+@@ -998,8 +923,8 @@ static int selinux_set_mnt_opts(struct super_block *sb,
+ static int selinux_cmp_sb_context(const struct super_block *oldsb,
+ 				    const struct super_block *newsb)
+ {
+-	struct superblock_security_struct *old = oldsb->s_security;
+-	struct superblock_security_struct *new = newsb->s_security;
++	struct superblock_security_struct *old = selinux_superblock(oldsb);
++	struct superblock_security_struct *new = selinux_superblock(newsb);
+ 	char oldflags = old->flags & SE_MNTMASK;
+ 	char newflags = new->flags & SE_MNTMASK;
+ 
+@@ -1031,8 +956,9 @@ static int selinux_sb_clone_mnt_opts(const struct super_block *oldsb,
+ 					unsigned long *set_kern_flags)
+ {
+ 	int rc = 0;
+-	const struct superblock_security_struct *oldsbsec = oldsb->s_security;
+-	struct superblock_security_struct *newsbsec = newsb->s_security;
++	const struct superblock_security_struct *oldsbsec =
++						selinux_superblock(oldsb);
++	struct superblock_security_struct *newsbsec = selinux_superblock(newsb);
+ 
+ 	int set_fscontext =	(oldsbsec->flags & FSCONTEXT_MNT);
+ 	int set_context =	(oldsbsec->flags & CONTEXT_MNT);
+@@ -1056,11 +982,8 @@ static int selinux_sb_clone_mnt_opts(const struct super_block *oldsb,
+ 	BUG_ON(!(oldsbsec->flags & SE_SBINITIALIZED));
+ 
+ 	/* if fs is reusing a sb, make sure that the contexts match */
+-	if (newsbsec->flags & SE_SBINITIALIZED) {
+-		if ((kern_flags & SECURITY_LSM_NATIVE_LABELS) && !set_context)
+-			*set_kern_flags |= SECURITY_LSM_NATIVE_LABELS;
++	if (newsbsec->flags & SE_SBINITIALIZED)
+ 		return selinux_cmp_sb_context(oldsb, newsb);
+-	}
+ 
+ 	mutex_lock(&newsbsec->lock);
+ 
+@@ -1107,12 +1030,14 @@ static int selinux_sb_clone_mnt_opts(const struct super_block *oldsb,
+ }
+ 
+ static int selinux_parse_opts_str(char *options,
+-				  struct security_mnt_opts *opts)
++				  struct security_mnt_opts *all_opts)
+ {
++	struct lsm_mnt_opts *opts = &all_opts->selinux;
+ 	char *p;
+ 	char *context = NULL, *defcontext = NULL;
+ 	char *fscontext = NULL, *rootcontext = NULL;
+-	int rc, num_mnt_opts = 0;
++	int rc = 0;
++	int num_mnt_opts = 0;
+ 
+ 	opts->num_mnt_opts = 0;
+ 
+@@ -1181,7 +1106,6 @@ static int selinux_parse_opts_str(char *options,
+ 		case Opt_labelsupport:
+ 			break;
+ 		default:
+-			rc = -EINVAL;
+ 			pr_warn("SELinux:  unknown mount option\n");
+ 			goto out_err;
+ 
+@@ -1219,7 +1143,7 @@ static int selinux_parse_opts_str(char *options,
+ 	return 0;
+ 
+ out_err:
+-	security_free_mnt_opts(opts);
++	security_free_mnt_opts(all_opts);
+ 	kfree(context);
+ 	kfree(defcontext);
+ 	kfree(fscontext);
+@@ -1255,8 +1179,9 @@ static int superblock_doinit(struct super_block *sb, void *data)
+ }
+ 
+ static void selinux_write_opts(struct seq_file *m,
+-			       struct security_mnt_opts *opts)
++			       struct security_mnt_opts *all_opts)
+ {
++	struct lsm_mnt_opts *opts = &all_opts->selinux;
+ 	int i;
+ 	char *prefix;
+ 
+@@ -1547,7 +1472,7 @@ static int selinux_genfs_get_sid(struct dentry *dentry,
+ static int inode_doinit_with_dentry(struct inode *inode, struct dentry *opt_dentry)
+ {
+ 	struct superblock_security_struct *sbsec = NULL;
+-	struct inode_security_struct *isec = inode->i_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 	u32 task_sid, sid = 0;
+ 	u16 sclass;
+ 	struct dentry *dentry;
+@@ -1566,7 +1491,7 @@ static int inode_doinit_with_dentry(struct inode *inode, struct dentry *opt_dent
+ 	if (isec->sclass == SECCLASS_FILE)
+ 		isec->sclass = inode_mode_to_security_class(inode->i_mode);
+ 
+-	sbsec = inode->i_sb->s_security;
++	sbsec = selinux_superblock(inode->i_sb);
+ 	if (!(sbsec->flags & SE_SBINITIALIZED)) {
+ 		/* Defer initialization until selinux_complete_init,
+ 		   after the initial policy is loaded and the security
+@@ -1794,7 +1719,7 @@ static inline u32 signal_to_av(int sig)
+ 
+ /* Check whether a task is allowed to use a capability. */
+ static int cred_has_capability(const struct cred *cred,
+-			       int cap, unsigned int opts, bool initns)
++			       int cap, int audit, bool initns)
+ {
+ 	struct common_audit_data ad;
+ 	struct av_decision avd;
+@@ -1821,7 +1746,7 @@ static int cred_has_capability(const struct cred *cred,
+ 
+ 	rc = avc_has_perm_noaudit(&selinux_state,
+ 				  sid, sid, sclass, av, 0, &avd);
+-	if (!(opts & CAP_OPT_NOAUDIT)) {
++	if (audit == SECURITY_CAP_AUDIT) {
+ 		int rc2 = avc_audit(&selinux_state,
+ 				    sid, sid, sclass, av, &avd, rc, &ad, 0);
+ 		if (rc2)
+@@ -1847,7 +1772,7 @@ static int inode_has_perm(const struct cred *cred,
+ 		return 0;
+ 
+ 	sid = cred_sid(cred);
+-	isec = inode->i_security;
++	isec = selinux_inode(inode);
+ 
+ 	return avc_has_perm(&selinux_state,
+ 			    sid, isec->sid, isec->sclass, perms, adp);
+@@ -1913,7 +1838,7 @@ static int file_has_perm(const struct cred *cred,
+ 			 struct file *file,
+ 			 u32 av)
+ {
+-	struct file_security_struct *fsec = file->f_security;
++	struct file_security_struct *fsec = selinux_file(file);
+ 	struct inode *inode = file_inode(file);
+ 	struct common_audit_data ad;
+ 	u32 sid = cred_sid(cred);
+@@ -1956,7 +1881,8 @@ selinux_determine_inode_label(const struct task_security_struct *tsec,
+ 				 const struct qstr *name, u16 tclass,
+ 				 u32 *_new_isid)
+ {
+-	const struct superblock_security_struct *sbsec = dir->i_sb->s_security;
++	const struct superblock_security_struct *sbsec =
++						selinux_superblock(dir->i_sb);
+ 
+ 	if ((sbsec->flags & SE_SBINITIALIZED) &&
+ 	    (sbsec->behavior == SECURITY_FS_USE_MNTPOINT)) {
+@@ -1979,7 +1905,7 @@ static int may_create(struct inode *dir,
+ 		      struct dentry *dentry,
+ 		      u16 tclass)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	struct inode_security_struct *dsec;
+ 	struct superblock_security_struct *sbsec;
+ 	u32 sid, newsid;
+@@ -1987,7 +1913,7 @@ static int may_create(struct inode *dir,
+ 	int rc;
+ 
+ 	dsec = inode_security(dir);
+-	sbsec = dir->i_sb->s_security;
++	sbsec = selinux_superblock(dir->i_sb);
+ 
+ 	sid = tsec->sid;
+ 
+@@ -2001,7 +1927,7 @@ static int may_create(struct inode *dir,
+ 	if (rc)
+ 		return rc;
+ 
+-	rc = selinux_determine_inode_label(current_security(), dir,
++	rc = selinux_determine_inode_label(selinux_cred(current_cred()), dir,
+ 					   &dentry->d_name, tclass, &newsid);
+ 	if (rc)
+ 		return rc;
+@@ -2136,7 +2062,7 @@ static int superblock_has_perm(const struct cred *cred,
+ 	struct superblock_security_struct *sbsec;
+ 	u32 sid = cred_sid(cred);
+ 
+-	sbsec = sb->s_security;
++	sbsec = selinux_superblock(sb);
+ 	return avc_has_perm(&selinux_state,
+ 			    sid, sbsec->sid, SECCLASS_FILESYSTEM, perms, ad);
+ }
+@@ -2257,7 +2183,7 @@ static int selinux_binder_transfer_file(struct task_struct *from,
+ 					struct file *file)
+ {
+ 	u32 sid = task_sid(to);
+-	struct file_security_struct *fsec = file->f_security;
++	struct file_security_struct *fsec = selinux_file(file);
+ 	struct dentry *dentry = file->f_path.dentry;
+ 	struct inode_security_struct *isec;
+ 	struct common_audit_data ad;
+@@ -2341,9 +2267,9 @@ static int selinux_capset(struct cred *new, const struct cred *old,
+  */
+ 
+ static int selinux_capable(const struct cred *cred, struct user_namespace *ns,
+-			   int cap, unsigned int opts)
++			   int cap, int audit)
+ {
+-	return cred_has_capability(cred, cap, opts, ns == &init_user_ns);
++	return cred_has_capability(cred, cap, audit, ns == &init_user_ns);
+ }
+ 
+ static int selinux_quotactl(int cmds, int type, int id, struct super_block *sb)
+@@ -2417,7 +2343,7 @@ static int selinux_vm_enough_memory(struct mm_struct *mm, long pages)
+ 	int rc, cap_sys_admin = 0;
+ 
+ 	rc = cred_has_capability(current_cred(), CAP_SYS_ADMIN,
+-				 CAP_OPT_NOAUDIT, true);
++				 SECURITY_CAP_NOAUDIT, true);
+ 	if (rc == 0)
+ 		cap_sys_admin = 1;
+ 
+@@ -2508,8 +2434,8 @@ static int selinux_bprm_set_creds(struct linux_binprm *bprm)
+ 	if (bprm->called_set_creds)
+ 		return 0;
+ 
+-	old_tsec = current_security();
+-	new_tsec = bprm->cred->security;
++	old_tsec = selinux_cred(current_cred());
++	new_tsec = selinux_cred(bprm->cred);
+ 	isec = inode_security(inode);
+ 
+ 	/* Default to the current task SID. */
+@@ -2673,7 +2599,7 @@ static void selinux_bprm_committing_creds(struct linux_binprm *bprm)
+ 	struct rlimit *rlim, *initrlim;
+ 	int rc, i;
+ 
+-	new_tsec = bprm->cred->security;
++	new_tsec = selinux_cred(bprm->cred);
+ 	if (new_tsec->sid == new_tsec->osid)
+ 		return;
+ 
+@@ -2716,7 +2642,7 @@ static void selinux_bprm_committing_creds(struct linux_binprm *bprm)
+  */
+ static void selinux_bprm_committed_creds(struct linux_binprm *bprm)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	struct itimerval itimer;
+ 	u32 osid, sid;
+ 	int rc, i;
+@@ -2767,11 +2693,6 @@ static int selinux_sb_alloc_security(struct super_block *sb)
+ 	return superblock_alloc_security(sb);
+ }
+ 
+-static void selinux_sb_free_security(struct super_block *sb)
+-{
+-	superblock_free_security(sb);
+-}
+-
+ static inline int match_prefix(char *prefix, int plen, char *option, int olen)
+ {
+ 	if (plen > olen)
+@@ -2866,9 +2787,10 @@ static int selinux_sb_copy_data(char *orig, char *copy)
+ static int selinux_sb_remount(struct super_block *sb, void *data)
+ {
+ 	int rc, i, *flags;
+-	struct security_mnt_opts opts;
++	struct security_mnt_opts all_opts;
++	struct lsm_mnt_opts *opts = &all_opts.selinux;
+ 	char *secdata, **mount_options;
+-	struct superblock_security_struct *sbsec = sb->s_security;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
+ 
+ 	if (!(sbsec->flags & SE_SBINITIALIZED))
+ 		return 0;
+@@ -2879,7 +2801,7 @@ static int selinux_sb_remount(struct super_block *sb, void *data)
+ 	if (sb->s_type->fs_flags & FS_BINARY_MOUNTDATA)
+ 		return 0;
+ 
+-	security_init_mnt_opts(&opts);
++	security_init_mnt_opts(&all_opts);
+ 	secdata = alloc_secdata();
+ 	if (!secdata)
+ 		return -ENOMEM;
+@@ -2887,14 +2809,14 @@ static int selinux_sb_remount(struct super_block *sb, void *data)
+ 	if (rc)
+ 		goto out_free_secdata;
+ 
+-	rc = selinux_parse_opts_str(secdata, &opts);
++	rc = selinux_parse_opts_str(secdata, &all_opts);
+ 	if (rc)
+ 		goto out_free_secdata;
+ 
+-	mount_options = opts.mnt_opts;
+-	flags = opts.mnt_opts_flags;
++	mount_options = opts->mnt_opts;
++	flags = opts->mnt_opts_flags;
+ 
+-	for (i = 0; i < opts.num_mnt_opts; i++) {
++	for (i = 0; i < opts->num_mnt_opts; i++) {
+ 		u32 sid;
+ 
+ 		if (flags[i] == SBLABEL_MNT)
+@@ -2937,7 +2859,7 @@ static int selinux_sb_remount(struct super_block *sb, void *data)
+ 
+ 	rc = 0;
+ out_free_opts:
+-	security_free_mnt_opts(&opts);
++	security_free_mnt_opts(&all_opts);
+ out_free_secdata:
+ 	free_secdata(secdata);
+ 	return rc;
+@@ -2959,7 +2881,7 @@ static int selinux_sb_kern_mount(struct super_block *sb, int flags, void *data)
+ 		return rc;
+ 
+ 	/* Allow all mounts performed by the kernel */
+-	if (flags & (MS_KERNMOUNT | MS_SUBMOUNT))
++	if (flags & MS_KERNMOUNT)
+ 		return 0;
+ 
+ 	ad.type = LSM_AUDIT_DATA_DENTRY;
+@@ -3012,22 +2934,28 @@ static void selinux_inode_free_security(struct inode *inode)
+ 	inode_free_security(inode);
+ }
+ 
++static void selinux_release_secctx(struct lsm_context *cp)
++{
++	kfree(cp->context);
++}
++
+ static int selinux_dentry_init_security(struct dentry *dentry, int mode,
+-					const struct qstr *name, void **ctx,
+-					u32 *ctxlen)
++					const struct qstr *name,
++					struct lsm_context *cp)
+ {
+ 	u32 newsid;
+ 	int rc;
+ 
+-	rc = selinux_determine_inode_label(current_security(),
++	rc = selinux_determine_inode_label(selinux_cred(current_cred()),
+ 					   d_inode(dentry->d_parent), name,
+ 					   inode_mode_to_security_class(mode),
+ 					   &newsid);
+ 	if (rc)
+ 		return rc;
+ 
+-	return security_sid_to_context(&selinux_state, newsid, (char **)ctx,
+-				       ctxlen);
++	cp->release = selinux_release_secctx;
++	return security_sid_to_context(&selinux_state, newsid, &cp->context,
++				       &cp->len);
+ }
+ 
+ static int selinux_dentry_create_files_as(struct dentry *dentry, int mode,
+@@ -3039,14 +2967,14 @@ static int selinux_dentry_create_files_as(struct dentry *dentry, int mode,
+ 	int rc;
+ 	struct task_security_struct *tsec;
+ 
+-	rc = selinux_determine_inode_label(old->security,
++	rc = selinux_determine_inode_label(selinux_cred(old),
+ 					   d_inode(dentry->d_parent), name,
+ 					   inode_mode_to_security_class(mode),
+ 					   &newsid);
+ 	if (rc)
+ 		return rc;
+ 
+-	tsec = new->security;
++	tsec = selinux_cred(new);
+ 	tsec->create_sid = newsid;
+ 	return 0;
+ }
+@@ -3056,17 +2984,17 @@ static int selinux_inode_init_security(struct inode *inode, struct inode *dir,
+ 				       const char **name,
+ 				       void **value, size_t *len)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	struct superblock_security_struct *sbsec;
+ 	u32 newsid, clen;
+ 	int rc;
+ 	char *context;
+ 
+-	sbsec = dir->i_sb->s_security;
++	sbsec = selinux_superblock(dir->i_sb);
+ 
+ 	newsid = tsec->create_sid;
+ 
+-	rc = selinux_determine_inode_label(current_security(),
++	rc = selinux_determine_inode_label(selinux_cred(current_cred()),
+ 		dir, qstr,
+ 		inode_mode_to_security_class(inode->i_mode),
+ 		&newsid);
+@@ -3075,7 +3003,7 @@ static int selinux_inode_init_security(struct inode *inode, struct inode *dir,
+ 
+ 	/* Possibly defer initialization to selinux_complete_init. */
+ 	if (sbsec->flags & SE_SBINITIALIZED) {
+-		struct inode_security_struct *isec = inode->i_security;
++		struct inode_security_struct *isec = selinux_inode(inode);
+ 		isec->sclass = inode_mode_to_security_class(inode->i_mode);
+ 		isec->sid = newsid;
+ 		isec->initialized = LABEL_INITIALIZED;
+@@ -3175,7 +3103,7 @@ static noinline int audit_inode_permission(struct inode *inode,
+ 					   unsigned flags)
+ {
+ 	struct common_audit_data ad;
+-	struct inode_security_struct *isec = inode->i_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 	int rc;
+ 
+ 	ad.type = LSM_AUDIT_DATA_INODE;
+@@ -3221,9 +3149,7 @@ static int selinux_inode_permission(struct inode *inode, int mask)
+ 		return PTR_ERR(isec);
+ 
+ 	rc = avc_has_perm_noaudit(&selinux_state,
+-				  sid, isec->sid, isec->sclass, perms,
+-				  (flags & MAY_NOT_BLOCK) ? AVC_NONBLOCKING : 0,
+-				  &avd);
++				  sid, isec->sid, isec->sclass, perms, 0, &avd);
+ 	audited = avc_audit_required(perms, &avd, rc,
+ 				     from_access ? FILE__AUDIT_ACCESS : 0,
+ 				     &denied);
+@@ -3272,11 +3198,11 @@ static int selinux_inode_getattr(const struct path *path)
+ static bool has_cap_mac_admin(bool audit)
+ {
+ 	const struct cred *cred = current_cred();
+-	unsigned int opts = audit ? CAP_OPT_NONE : CAP_OPT_NOAUDIT;
++	int cap_audit = audit ? SECURITY_CAP_AUDIT : SECURITY_CAP_NOAUDIT;
+ 
+-	if (cap_capable(cred, &init_user_ns, CAP_MAC_ADMIN, opts))
++	if (cap_capable(cred, &init_user_ns, CAP_MAC_ADMIN, cap_audit))
+ 		return false;
+-	if (cred_has_capability(cred, CAP_MAC_ADMIN, opts, true))
++	if (cred_has_capability(cred, CAP_MAC_ADMIN, cap_audit, true))
+ 		return false;
+ 	return true;
+ }
+@@ -3292,16 +3218,13 @@ static int selinux_inode_setxattr(struct dentry *dentry, const char *name,
+ 	int rc = 0;
+ 
+ 	if (strcmp(name, XATTR_NAME_SELINUX)) {
+-		rc = cap_inode_setxattr(dentry, name, value, size, flags);
+-		if (rc)
+-			return rc;
+-
+ 		/* Not an attribute we recognize, so just check the
+ 		   ordinary setattr permission. */
+-		return dentry_has_perm(current_cred(), dentry, FILE__SETATTR);
++		rc = dentry_has_perm(current_cred(), dentry, FILE__SETATTR);
++		return rc ? rc : -ENOSYS;
+ 	}
+ 
+-	sbsec = inode->i_sb->s_security;
++	sbsec = selinux_superblock(inode->i_sb);
+ 	if (!(sbsec->flags & SBLABEL_MNT))
+ 		return -EOPNOTSUPP;
+ 
+@@ -3482,16 +3405,12 @@ static int selinux_inode_setsecurity(struct inode *inode, const char *name,
+ 				     const void *value, size_t size, int flags)
+ {
+ 	struct inode_security_struct *isec = inode_security_novalidate(inode);
+-	struct superblock_security_struct *sbsec = inode->i_sb->s_security;
+ 	u32 newsid;
+ 	int rc;
+ 
+ 	if (strcmp(name, XATTR_SELINUX_SUFFIX))
+ 		return -EOPNOTSUPP;
+ 
+-	if (!(sbsec->flags & SBLABEL_MNT))
+-		return -EOPNOTSUPP;
+-
+ 	if (!value || !size)
+ 		return -EACCES;
+ 
+@@ -3516,15 +3435,16 @@ static int selinux_inode_listsecurity(struct inode *inode, char *buffer, size_t
+ 	return len;
+ }
+ 
+-static void selinux_inode_getsecid(struct inode *inode, u32 *secid)
++static void selinux_inode_getsecid(struct inode *inode, struct lsm_export *l)
+ {
+ 	struct inode_security_struct *isec = inode_security_novalidate(inode);
+-	*secid = isec->sid;
++
++	selinux_export_secid(l, isec->sid);
+ }
+ 
+ static int selinux_inode_copy_up(struct dentry *src, struct cred **new)
+ {
+-	u32 sid;
++	struct lsm_export l;
+ 	struct task_security_struct *tsec;
+ 	struct cred *new_creds = *new;
+ 
+@@ -3534,10 +3454,11 @@ static int selinux_inode_copy_up(struct dentry *src, struct cred **new)
+ 			return -ENOMEM;
+ 	}
+ 
+-	tsec = new_creds->security;
++	tsec = selinux_cred(new_creds);
+ 	/* Get label from overlay inode and set it in create_sid */
+-	selinux_inode_getsecid(d_inode(src), &sid);
+-	tsec->create_sid = sid;
++	lsm_export_init(&l);
++	selinux_inode_getsecid(d_inode(src), &l);
++	tsec->create_sid = l.selinux;
+ 	*new = new_creds;
+ 	return 0;
+ }
+@@ -3575,7 +3496,7 @@ static int selinux_revalidate_file_permission(struct file *file, int mask)
+ static int selinux_file_permission(struct file *file, int mask)
+ {
+ 	struct inode *inode = file_inode(file);
+-	struct file_security_struct *fsec = file->f_security;
++	struct file_security_struct *fsec = selinux_file(file);
+ 	struct inode_security_struct *isec;
+ 	u32 sid = current_sid();
+ 
+@@ -3597,11 +3518,6 @@ static int selinux_file_alloc_security(struct file *file)
+ 	return file_alloc_security(file);
+ }
+ 
+-static void selinux_file_free_security(struct file *file)
+-{
+-	file_free_security(file);
+-}
+-
+ /*
+  * Check whether a task has the ioctl permission and cmd
+  * operation to an inode.
+@@ -3610,7 +3526,7 @@ static int ioctl_has_perm(const struct cred *cred, struct file *file,
+ 		u32 requested, u16 cmd)
+ {
+ 	struct common_audit_data ad;
+-	struct file_security_struct *fsec = file->f_security;
++	struct file_security_struct *fsec = selinux_file(file);
+ 	struct inode *inode = file_inode(file);
+ 	struct inode_security_struct *isec;
+ 	struct lsm_ioctlop_audit ioctl;
+@@ -3680,7 +3596,7 @@ static int selinux_file_ioctl(struct file *file, unsigned int cmd,
+ 	case KDSKBENT:
+ 	case KDSKBSENT:
+ 		error = cred_has_capability(cred, CAP_SYS_TTY_CONFIG,
+-					    CAP_OPT_NONE, true);
++					    SECURITY_CAP_AUDIT, true);
+ 		break;
+ 
+ 	/* default case assumes that the command will go
+@@ -3862,7 +3778,7 @@ static void selinux_file_set_fowner(struct file *file)
+ {
+ 	struct file_security_struct *fsec;
+ 
+-	fsec = file->f_security;
++	fsec = selinux_file(file);
+ 	fsec->fown_sid = current_sid();
+ }
+ 
+@@ -3877,7 +3793,7 @@ static int selinux_file_send_sigiotask(struct task_struct *tsk,
+ 	/* struct fown_struct is never outside the context of a struct file */
+ 	file = container_of(fown, struct file, f_owner);
+ 
+-	fsec = file->f_security;
++	fsec = selinux_file(file);
+ 
+ 	if (!signum)
+ 		perm = signal_to_av(SIGIO); /* as per send_sigio_to_task */
+@@ -3901,7 +3817,7 @@ static int selinux_file_open(struct file *file)
+ 	struct file_security_struct *fsec;
+ 	struct inode_security_struct *isec;
+ 
+-	fsec = file->f_security;
++	fsec = selinux_file(file);
+ 	isec = inode_security(file_inode(file));
+ 	/*
+ 	 * Save inode label and policy sequence number
+@@ -3934,53 +3850,16 @@ static int selinux_task_alloc(struct task_struct *task,
+ 			    sid, sid, SECCLASS_PROCESS, PROCESS__FORK, NULL);
+ }
+ 
+-/*
+- * allocate the SELinux part of blank credentials
+- */
+-static int selinux_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+-{
+-	struct task_security_struct *tsec;
+-
+-	tsec = kzalloc(sizeof(struct task_security_struct), gfp);
+-	if (!tsec)
+-		return -ENOMEM;
+-
+-	cred->security = tsec;
+-	return 0;
+-}
+-
+-/*
+- * detach and free the LSM part of a set of credentials
+- */
+-static void selinux_cred_free(struct cred *cred)
+-{
+-	struct task_security_struct *tsec = cred->security;
+-
+-	/*
+-	 * cred->security == NULL if security_cred_alloc_blank() or
+-	 * security_prepare_creds() returned an error.
+-	 */
+-	BUG_ON(cred->security && (unsigned long) cred->security < PAGE_SIZE);
+-	cred->security = (void *) 0x7UL;
+-	kfree(tsec);
+-}
+-
+ /*
+  * prepare a new set of credentials for modification
+  */
+ static int selinux_cred_prepare(struct cred *new, const struct cred *old,
+ 				gfp_t gfp)
+ {
+-	const struct task_security_struct *old_tsec;
+-	struct task_security_struct *tsec;
+-
+-	old_tsec = old->security;
++	const struct task_security_struct *old_tsec = selinux_cred(old);
++	struct task_security_struct *tsec = selinux_cred(new);
+ 
+-	tsec = kmemdup(old_tsec, sizeof(struct task_security_struct), gfp);
+-	if (!tsec)
+-		return -ENOMEM;
+-
+-	new->security = tsec;
++	*tsec = *old_tsec;
+ 	return 0;
+ }
+ 
+@@ -3989,34 +3868,37 @@ static int selinux_cred_prepare(struct cred *new, const struct cred *old,
+  */
+ static void selinux_cred_transfer(struct cred *new, const struct cred *old)
+ {
+-	const struct task_security_struct *old_tsec = old->security;
+-	struct task_security_struct *tsec = new->security;
++	const struct task_security_struct *old_tsec = selinux_cred(old);
++	struct task_security_struct *tsec = selinux_cred(new);
+ 
+ 	*tsec = *old_tsec;
+ }
+ 
+-static void selinux_cred_getsecid(const struct cred *c, u32 *secid)
++static void selinux_cred_getsecid(const struct cred *c, struct lsm_export *l)
+ {
+-	*secid = cred_sid(c);
++	selinux_export_secid(l, cred_sid(c));
+ }
+ 
+ /*
+  * set the security data for a kernel service
+  * - all the creation contexts are set to unlabelled
+  */
+-static int selinux_kernel_act_as(struct cred *new, u32 secid)
++static int selinux_kernel_act_as(struct cred *new, struct lsm_export *l)
+ {
+-	struct task_security_struct *tsec = new->security;
++	struct task_security_struct *tsec = selinux_cred(new);
++	u32 nsid;
+ 	u32 sid = current_sid();
+ 	int ret;
+ 
++	selinux_import_secid(l, &nsid);
++
+ 	ret = avc_has_perm(&selinux_state,
+-			   sid, secid,
++			   sid, nsid,
+ 			   SECCLASS_KERNEL_SERVICE,
+ 			   KERNEL_SERVICE__USE_AS_OVERRIDE,
+ 			   NULL);
+ 	if (ret == 0) {
+-		tsec->sid = secid;
++		tsec->sid = nsid;
+ 		tsec->create_sid = 0;
+ 		tsec->keycreate_sid = 0;
+ 		tsec->sockcreate_sid = 0;
+@@ -4031,7 +3913,7 @@ static int selinux_kernel_act_as(struct cred *new, u32 secid)
+ static int selinux_kernel_create_files_as(struct cred *new, struct inode *inode)
+ {
+ 	struct inode_security_struct *isec = inode_security(inode);
+-	struct task_security_struct *tsec = new->security;
++	struct task_security_struct *tsec = selinux_cred(new);
+ 	u32 sid = current_sid();
+ 	int ret;
+ 
+@@ -4077,7 +3959,7 @@ static int selinux_kernel_module_from_file(struct file *file)
+ 	ad.type = LSM_AUDIT_DATA_FILE;
+ 	ad.u.file = file;
+ 
+-	fsec = file->f_security;
++	fsec = selinux_file(file);
+ 	if (sid != fsec->sid) {
+ 		rc = avc_has_perm(&selinux_state,
+ 				  sid, fsec->sid, SECCLASS_FD, FD__USE, &ad);
+@@ -4142,9 +4024,9 @@ static int selinux_task_getsid(struct task_struct *p)
+ 			    PROCESS__GETSESSION, NULL);
+ }
+ 
+-static void selinux_task_getsecid(struct task_struct *p, u32 *secid)
++static void selinux_task_getsecid(struct task_struct *p, struct lsm_export *l)
+ {
+-	*secid = task_sid(p);
++	selinux_export_secid(l, task_sid(p));
+ }
+ 
+ static int selinux_task_setnice(struct task_struct *p, int nice)
+@@ -4243,7 +4125,7 @@ static int selinux_task_kill(struct task_struct *p, struct siginfo *info,
+ static void selinux_task_to_inode(struct task_struct *p,
+ 				  struct inode *inode)
+ {
+-	struct inode_security_struct *isec = inode->i_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 	u32 sid = task_sid(p);
+ 
+ 	spin_lock(&isec->lock);
+@@ -4561,7 +4443,7 @@ static int socket_sockcreate_sid(const struct task_security_struct *tsec,
+ 
+ static int sock_has_perm(struct sock *sk, u32 perms)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct common_audit_data ad;
+ 	struct lsm_network_audit net = {0,};
+ 
+@@ -4580,7 +4462,7 @@ static int sock_has_perm(struct sock *sk, u32 perms)
+ static int selinux_socket_create(int family, int type,
+ 				 int protocol, int kern)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	u32 newsid;
+ 	u16 secclass;
+ 	int rc;
+@@ -4600,7 +4482,7 @@ static int selinux_socket_create(int family, int type,
+ static int selinux_socket_post_create(struct socket *sock, int family,
+ 				      int type, int protocol, int kern)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	struct inode_security_struct *isec = inode_security_novalidate(SOCK_INODE(sock));
+ 	struct sk_security_struct *sksec;
+ 	u16 sclass = socket_type_to_security_class(family, type, protocol);
+@@ -4618,7 +4500,7 @@ static int selinux_socket_post_create(struct socket *sock, int family,
+ 	isec->initialized = LABEL_INITIALIZED;
+ 
+ 	if (sock->sk) {
+-		sksec = sock->sk->sk_security;
++		sksec = selinux_sock(sock->sk);
+ 		sksec->sclass = sclass;
+ 		sksec->sid = sid;
+ 		/* Allows detection of the first association on this socket */
+@@ -4634,8 +4516,8 @@ static int selinux_socket_post_create(struct socket *sock, int family,
+ static int selinux_socket_socketpair(struct socket *socka,
+ 				     struct socket *sockb)
+ {
+-	struct sk_security_struct *sksec_a = socka->sk->sk_security;
+-	struct sk_security_struct *sksec_b = sockb->sk->sk_security;
++	struct sk_security_struct *sksec_a = selinux_sock(socka->sk);
++	struct sk_security_struct *sksec_b = selinux_sock(sockb->sk);
+ 
+ 	sksec_a->peer_sid = sksec_b->sid;
+ 	sksec_b->peer_sid = sksec_a->sid;
+@@ -4650,7 +4532,7 @@ static int selinux_socket_socketpair(struct socket *socka,
+ static int selinux_socket_bind(struct socket *sock, struct sockaddr *address, int addrlen)
+ {
+ 	struct sock *sk = sock->sk;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	u16 family;
+ 	int err;
+ 
+@@ -4782,7 +4664,7 @@ static int selinux_socket_connect_helper(struct socket *sock,
+ 					 struct sockaddr *address, int addrlen)
+ {
+ 	struct sock *sk = sock->sk;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	int err;
+ 
+ 	err = sock_has_perm(sk, SOCKET__CONNECT);
+@@ -4800,7 +4682,7 @@ static int selinux_socket_connect_helper(struct socket *sock,
+ 		struct lsm_network_audit net = {0,};
+ 		struct sockaddr_in *addr4 = NULL;
+ 		struct sockaddr_in6 *addr6 = NULL;
+-		unsigned short snum = 0;
++		unsigned short snum;
+ 		u32 sid, perm;
+ 
+ 		/* sctp_connectx(3) calls via selinux_sctp_bind_connect()
+@@ -4823,12 +4705,12 @@ static int selinux_socket_connect_helper(struct socket *sock,
+ 			break;
+ 		default:
+ 			/* Note that SCTP services expect -EINVAL, whereas
+-			 * others must handle this at the protocol level:
+-			 * connect(AF_UNSPEC) on a connected socket is
+-			 * a documented way disconnect the socket.
++			 * others expect -EAFNOSUPPORT.
+ 			 */
+ 			if (sksec->sclass == SECCLASS_SCTP_SOCKET)
+ 				return -EINVAL;
++			else
++				return -EAFNOSUPPORT;
+ 		}
+ 
+ 		err = sel_netport_sid(sk->sk_protocol, snum, &sid);
+@@ -4953,9 +4835,9 @@ static int selinux_socket_unix_stream_connect(struct sock *sock,
+ 					      struct sock *other,
+ 					      struct sock *newsk)
+ {
+-	struct sk_security_struct *sksec_sock = sock->sk_security;
+-	struct sk_security_struct *sksec_other = other->sk_security;
+-	struct sk_security_struct *sksec_new = newsk->sk_security;
++	struct sk_security_struct *sksec_sock = selinux_sock(sock);
++	struct sk_security_struct *sksec_other = selinux_sock(other);
++	struct sk_security_struct *sksec_new = selinux_sock(newsk);
+ 	struct common_audit_data ad;
+ 	struct lsm_network_audit net = {0,};
+ 	int err;
+@@ -4987,8 +4869,8 @@ static int selinux_socket_unix_stream_connect(struct sock *sock,
+ static int selinux_socket_unix_may_send(struct socket *sock,
+ 					struct socket *other)
+ {
+-	struct sk_security_struct *ssec = sock->sk->sk_security;
+-	struct sk_security_struct *osec = other->sk->sk_security;
++	struct sk_security_struct *ssec = selinux_sock(sock->sk);
++	struct sk_security_struct *osec = selinux_sock(other->sk);
+ 	struct common_audit_data ad;
+ 	struct lsm_network_audit net = {0,};
+ 
+@@ -5030,7 +4912,7 @@ static int selinux_sock_rcv_skb_compat(struct sock *sk, struct sk_buff *skb,
+ 				       u16 family)
+ {
+ 	int err = 0;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	u32 sk_sid = sksec->sid;
+ 	struct common_audit_data ad;
+ 	struct lsm_network_audit net = {0,};
+@@ -5063,7 +4945,7 @@ static int selinux_sock_rcv_skb_compat(struct sock *sk, struct sk_buff *skb,
+ static int selinux_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ {
+ 	int err;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	u16 family = sk->sk_family;
+ 	u32 sk_sid = sksec->sid;
+ 	struct common_audit_data ad;
+@@ -5131,13 +5013,15 @@ static int selinux_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ 	return err;
+ }
+ 
+-static int selinux_socket_getpeersec_stream(struct socket *sock, char __user *optval,
+-					    int __user *optlen, unsigned len)
++static int selinux_socket_getpeersec_stream(struct socket *sock,
++					    __user char *optval,
++					    __user int *optlen,
++					    unsigned int len)
+ {
+ 	int err = 0;
+ 	char *scontext;
+ 	u32 scontext_len;
+-	struct sk_security_struct *sksec = sock->sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sock->sk);
+ 	u32 peer_sid = SECSID_NULL;
+ 
+ 	if (sksec->sclass == SECCLASS_UNIX_STREAM_SOCKET ||
+@@ -5167,7 +5051,9 @@ static int selinux_socket_getpeersec_stream(struct socket *sock, char __user *op
+ 	return err;
+ }
+ 
+-static int selinux_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *skb, u32 *secid)
++static int selinux_socket_getpeersec_dgram(struct socket *sock,
++					   struct sk_buff *skb,
++					   struct lsm_export *l)
+ {
+ 	u32 peer_secid = SECSID_NULL;
+ 	u16 family;
+@@ -5189,7 +5075,7 @@ static int selinux_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *
+ 		selinux_skb_peerlbl_sid(skb, family, &peer_secid);
+ 
+ out:
+-	*secid = peer_secid;
++	selinux_export_secid(l, peer_secid);
+ 	if (peer_secid == SECSID_NULL)
+ 		return -EINVAL;
+ 	return 0;
+@@ -5197,34 +5083,27 @@ static int selinux_socket_getpeersec_dgram(struct socket *sock, struct sk_buff *
+ 
+ static int selinux_sk_alloc_security(struct sock *sk, int family, gfp_t priority)
+ {
+-	struct sk_security_struct *sksec;
+-
+-	sksec = kzalloc(sizeof(*sksec), priority);
+-	if (!sksec)
+-		return -ENOMEM;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	sksec->peer_sid = SECINITSID_UNLABELED;
+ 	sksec->sid = SECINITSID_UNLABELED;
+ 	sksec->sclass = SECCLASS_SOCKET;
+ 	selinux_netlbl_sk_security_reset(sksec);
+-	sk->sk_security = sksec;
+ 
+ 	return 0;
+ }
+ 
+ static void selinux_sk_free_security(struct sock *sk)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+-	sk->sk_security = NULL;
+ 	selinux_netlbl_sk_security_free(sksec);
+-	kfree(sksec);
+ }
+ 
+ static void selinux_sk_clone_security(const struct sock *sk, struct sock *newsk)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
+-	struct sk_security_struct *newsksec = newsk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
++	struct sk_security_struct *newsksec = selinux_sock(newsk);
+ 
+ 	newsksec->sid = sksec->sid;
+ 	newsksec->peer_sid = sksec->peer_sid;
+@@ -5238,7 +5117,7 @@ static void selinux_sk_getsecid(struct sock *sk, u32 *secid)
+ 	if (!sk)
+ 		*secid = SECINITSID_ANY_SOCKET;
+ 	else {
+-		struct sk_security_struct *sksec = sk->sk_security;
++		struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 		*secid = sksec->sid;
+ 	}
+@@ -5248,7 +5127,7 @@ static void selinux_sock_graft(struct sock *sk, struct socket *parent)
+ {
+ 	struct inode_security_struct *isec =
+ 		inode_security_novalidate(SOCK_INODE(parent));
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	if (sk->sk_family == PF_INET || sk->sk_family == PF_INET6 ||
+ 	    sk->sk_family == PF_UNIX)
+@@ -5263,7 +5142,7 @@ static void selinux_sock_graft(struct sock *sk, struct socket *parent)
+ static int selinux_sctp_assoc_request(struct sctp_endpoint *ep,
+ 				      struct sk_buff *skb)
+ {
+-	struct sk_security_struct *sksec = ep->base.sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(ep->base.sk);
+ 	struct common_audit_data ad;
+ 	struct lsm_network_audit net = {0,};
+ 	u8 peerlbl_active;
+@@ -5349,9 +5228,6 @@ static int selinux_sctp_bind_connect(struct sock *sk, int optname,
+ 	addr_buf = address;
+ 
+ 	while (walk_size < addrlen) {
+-		if (walk_size + sizeof(sa_family_t) > addrlen)
+-			return -EINVAL;
+-
+ 		addr = addr_buf;
+ 		switch (addr->sa_family) {
+ 		case AF_UNSPEC:
+@@ -5365,9 +5241,6 @@ static int selinux_sctp_bind_connect(struct sock *sk, int optname,
+ 			return -EINVAL;
+ 		}
+ 
+-		if (walk_size + len > addrlen)
+-			return -EINVAL;
+-
+ 		err = -EINVAL;
+ 		switch (optname) {
+ 		/* Bind checks */
+@@ -5414,8 +5287,8 @@ static int selinux_sctp_bind_connect(struct sock *sk, int optname,
+ static void selinux_sctp_sk_clone(struct sctp_endpoint *ep, struct sock *sk,
+ 				  struct sock *newsk)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
+-	struct sk_security_struct *newsksec = newsk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
++	struct sk_security_struct *newsksec = selinux_sock(newsk);
+ 
+ 	/* If policy does not support SECCLASS_SCTP_SOCKET then call
+ 	 * the non-sctp clone version.
+@@ -5432,7 +5305,7 @@ static void selinux_sctp_sk_clone(struct sctp_endpoint *ep, struct sock *sk,
+ static int selinux_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ 				     struct request_sock *req)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	int err;
+ 	u16 family = req->rsk_ops->family;
+ 	u32 connsid;
+@@ -5453,7 +5326,7 @@ static int selinux_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ static void selinux_inet_csk_clone(struct sock *newsk,
+ 				   const struct request_sock *req)
+ {
+-	struct sk_security_struct *newsksec = newsk->sk_security;
++	struct sk_security_struct *newsksec = selinux_sock(newsk);
+ 
+ 	newsksec->sid = req->secid;
+ 	newsksec->peer_sid = req->peer_secid;
+@@ -5470,7 +5343,7 @@ static void selinux_inet_csk_clone(struct sock *newsk,
+ static void selinux_inet_conn_established(struct sock *sk, struct sk_buff *skb)
+ {
+ 	u16 family = sk->sk_family;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	/* handle mapped IPv4 packets arriving via IPv6 sockets */
+ 	if (family == PF_INET6 && skb->protocol == htons(ETH_P_IP))
+@@ -5484,7 +5357,7 @@ static int selinux_secmark_relabel_packet(u32 sid)
+ 	const struct task_security_struct *__tsec;
+ 	u32 tsid;
+ 
+-	__tsec = current_security();
++	__tsec = selinux_cred(current_cred());
+ 	tsid = __tsec->sid;
+ 
+ 	return avc_has_perm(&selinux_state,
+@@ -5554,7 +5427,7 @@ static int selinux_tun_dev_attach_queue(void *security)
+ static int selinux_tun_dev_attach(struct sock *sk, void *security)
+ {
+ 	struct tun_security_struct *tunsec = security;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	/* we don't currently perform any NetLabel based labeling here and it
+ 	 * isn't clear that we would want to do so anyway; while we could apply
+@@ -5595,7 +5468,7 @@ static int selinux_nlmsg_perm(struct sock *sk, struct sk_buff *skb)
+ 	int err = 0;
+ 	u32 perm;
+ 	struct nlmsghdr *nlh;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	if (skb->len < NLMSG_HDRLEN) {
+ 		err = -EINVAL;
+@@ -5736,7 +5609,7 @@ static unsigned int selinux_ip_output(struct sk_buff *skb,
+ 			return NF_ACCEPT;
+ 
+ 		/* standard practice, label using the parent socket */
+-		sksec = sk->sk_security;
++		sksec = selinux_sock(sk);
+ 		sid = sksec->sid;
+ 	} else
+ 		sid = SECINITSID_KERNEL;
+@@ -5775,7 +5648,7 @@ static unsigned int selinux_ip_postroute_compat(struct sk_buff *skb,
+ 
+ 	if (sk == NULL)
+ 		return NF_ACCEPT;
+-	sksec = sk->sk_security;
++	sksec = selinux_sock(sk);
+ 
+ 	ad.type = LSM_AUDIT_DATA_NET;
+ 	ad.u.net = &net;
+@@ -5867,7 +5740,7 @@ static unsigned int selinux_ip_postroute(struct sk_buff *skb,
+ 		u32 skb_sid;
+ 		struct sk_security_struct *sksec;
+ 
+-		sksec = sk->sk_security;
++		sksec = selinux_sock(sk);
+ 		if (selinux_skb_peerlbl_sid(skb, family, &skb_sid))
+ 			return NF_DROP;
+ 		/* At this point, if the returned skb peerlbl is SECSID_NULL
+@@ -5896,7 +5769,7 @@ static unsigned int selinux_ip_postroute(struct sk_buff *skb,
+ 	} else {
+ 		/* Locally generated packet, fetch the security label from the
+ 		 * associated socket. */
+-		struct sk_security_struct *sksec = sk->sk_security;
++		struct sk_security_struct *sksec = selinux_sock(sk);
+ 		peer_sid = sksec->sid;
+ 		secmark_perm = PACKET__SEND;
+ 	}
+@@ -5959,51 +5832,22 @@ static int selinux_netlink_send(struct sock *sk, struct sk_buff *skb)
+ 	return selinux_nlmsg_perm(sk, skb);
+ }
+ 
+-static int ipc_alloc_security(struct kern_ipc_perm *perm,
+-			      u16 sclass)
++static void ipc_init_security(struct ipc_security_struct *isec, u16 sclass)
+ {
+-	struct ipc_security_struct *isec;
+-
+-	isec = kzalloc(sizeof(struct ipc_security_struct), GFP_KERNEL);
+-	if (!isec)
+-		return -ENOMEM;
+-
+ 	isec->sclass = sclass;
+ 	isec->sid = current_sid();
+-	perm->security = isec;
+-
+-	return 0;
+-}
+-
+-static void ipc_free_security(struct kern_ipc_perm *perm)
+-{
+-	struct ipc_security_struct *isec = perm->security;
+-	perm->security = NULL;
+-	kfree(isec);
+ }
+ 
+ static int msg_msg_alloc_security(struct msg_msg *msg)
+ {
+ 	struct msg_security_struct *msec;
+ 
+-	msec = kzalloc(sizeof(struct msg_security_struct), GFP_KERNEL);
+-	if (!msec)
+-		return -ENOMEM;
+-
++	msec = selinux_msg_msg(msg);
+ 	msec->sid = SECINITSID_UNLABELED;
+-	msg->security = msec;
+ 
+ 	return 0;
+ }
+ 
+-static void msg_msg_free_security(struct msg_msg *msg)
+-{
+-	struct msg_security_struct *msec = msg->security;
+-
+-	msg->security = NULL;
+-	kfree(msec);
+-}
+-
+ static int ipc_has_perm(struct kern_ipc_perm *ipc_perms,
+ 			u32 perms)
+ {
+@@ -6011,7 +5855,7 @@ static int ipc_has_perm(struct kern_ipc_perm *ipc_perms,
+ 	struct common_audit_data ad;
+ 	u32 sid = current_sid();
+ 
+-	isec = ipc_perms->security;
++	isec = selinux_ipc(ipc_perms);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = ipc_perms->key;
+@@ -6025,11 +5869,6 @@ static int selinux_msg_msg_alloc_security(struct msg_msg *msg)
+ 	return msg_msg_alloc_security(msg);
+ }
+ 
+-static void selinux_msg_msg_free_security(struct msg_msg *msg)
+-{
+-	msg_msg_free_security(msg);
+-}
+-
+ /* message queue security operations */
+ static int selinux_msg_queue_alloc_security(struct kern_ipc_perm *msq)
+ {
+@@ -6038,11 +5877,8 @@ static int selinux_msg_queue_alloc_security(struct kern_ipc_perm *msq)
+ 	u32 sid = current_sid();
+ 	int rc;
+ 
+-	rc = ipc_alloc_security(msq, SECCLASS_MSGQ);
+-	if (rc)
+-		return rc;
+-
+-	isec = msq->security;
++	isec = selinux_ipc(msq);
++	ipc_init_security(isec, SECCLASS_MSGQ);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = msq->key;
+@@ -6050,16 +5886,7 @@ static int selinux_msg_queue_alloc_security(struct kern_ipc_perm *msq)
+ 	rc = avc_has_perm(&selinux_state,
+ 			  sid, isec->sid, SECCLASS_MSGQ,
+ 			  MSGQ__CREATE, &ad);
+-	if (rc) {
+-		ipc_free_security(msq);
+-		return rc;
+-	}
+-	return 0;
+-}
+-
+-static void selinux_msg_queue_free_security(struct kern_ipc_perm *msq)
+-{
+-	ipc_free_security(msq);
++	return rc;
+ }
+ 
+ static int selinux_msg_queue_associate(struct kern_ipc_perm *msq, int msqflg)
+@@ -6068,7 +5895,7 @@ static int selinux_msg_queue_associate(struct kern_ipc_perm *msq, int msqflg)
+ 	struct common_audit_data ad;
+ 	u32 sid = current_sid();
+ 
+-	isec = msq->security;
++	isec = selinux_ipc(msq);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = msq->key;
+@@ -6117,8 +5944,8 @@ static int selinux_msg_queue_msgsnd(struct kern_ipc_perm *msq, struct msg_msg *m
+ 	u32 sid = current_sid();
+ 	int rc;
+ 
+-	isec = msq->security;
+-	msec = msg->security;
++	isec = selinux_ipc(msq);
++	msec = selinux_msg_msg(msg);
+ 
+ 	/*
+ 	 * First time through, need to assign label to the message
+@@ -6165,8 +5992,8 @@ static int selinux_msg_queue_msgrcv(struct kern_ipc_perm *msq, struct msg_msg *m
+ 	u32 sid = task_sid(target);
+ 	int rc;
+ 
+-	isec = msq->security;
+-	msec = msg->security;
++	isec = selinux_ipc(msq);
++	msec = selinux_msg_msg(msg);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = msq->key;
+@@ -6189,11 +6016,8 @@ static int selinux_shm_alloc_security(struct kern_ipc_perm *shp)
+ 	u32 sid = current_sid();
+ 	int rc;
+ 
+-	rc = ipc_alloc_security(shp, SECCLASS_SHM);
+-	if (rc)
+-		return rc;
+-
+-	isec = shp->security;
++	isec = selinux_ipc(shp);
++	ipc_init_security(isec, SECCLASS_SHM);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = shp->key;
+@@ -6201,16 +6025,7 @@ static int selinux_shm_alloc_security(struct kern_ipc_perm *shp)
+ 	rc = avc_has_perm(&selinux_state,
+ 			  sid, isec->sid, SECCLASS_SHM,
+ 			  SHM__CREATE, &ad);
+-	if (rc) {
+-		ipc_free_security(shp);
+-		return rc;
+-	}
+-	return 0;
+-}
+-
+-static void selinux_shm_free_security(struct kern_ipc_perm *shp)
+-{
+-	ipc_free_security(shp);
++	return rc;
+ }
+ 
+ static int selinux_shm_associate(struct kern_ipc_perm *shp, int shmflg)
+@@ -6219,7 +6034,7 @@ static int selinux_shm_associate(struct kern_ipc_perm *shp, int shmflg)
+ 	struct common_audit_data ad;
+ 	u32 sid = current_sid();
+ 
+-	isec = shp->security;
++	isec = selinux_ipc(shp);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = shp->key;
+@@ -6286,11 +6101,8 @@ static int selinux_sem_alloc_security(struct kern_ipc_perm *sma)
+ 	u32 sid = current_sid();
+ 	int rc;
+ 
+-	rc = ipc_alloc_security(sma, SECCLASS_SEM);
+-	if (rc)
+-		return rc;
+-
+-	isec = sma->security;
++	isec = selinux_ipc(sma);
++	ipc_init_security(isec, SECCLASS_SEM);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = sma->key;
+@@ -6298,16 +6110,7 @@ static int selinux_sem_alloc_security(struct kern_ipc_perm *sma)
+ 	rc = avc_has_perm(&selinux_state,
+ 			  sid, isec->sid, SECCLASS_SEM,
+ 			  SEM__CREATE, &ad);
+-	if (rc) {
+-		ipc_free_security(sma);
+-		return rc;
+-	}
+-	return 0;
+-}
+-
+-static void selinux_sem_free_security(struct kern_ipc_perm *sma)
+-{
+-	ipc_free_security(sma);
++	return rc;
+ }
+ 
+ static int selinux_sem_associate(struct kern_ipc_perm *sma, int semflg)
+@@ -6316,7 +6119,7 @@ static int selinux_sem_associate(struct kern_ipc_perm *sma, int semflg)
+ 	struct common_audit_data ad;
+ 	u32 sid = current_sid();
+ 
+-	isec = sma->security;
++	isec = selinux_ipc(sma);
+ 
+ 	ad.type = LSM_AUDIT_DATA_IPC;
+ 	ad.u.ipc_id = sma->key;
+@@ -6400,10 +6203,12 @@ static int selinux_ipc_permission(struct kern_ipc_perm *ipcp, short flag)
+ 	return ipc_has_perm(ipcp, av);
+ }
+ 
+-static void selinux_ipc_getsecid(struct kern_ipc_perm *ipcp, u32 *secid)
++static void selinux_ipc_getsecid(struct kern_ipc_perm *ipcp,
++				 struct lsm_export *l)
+ {
+-	struct ipc_security_struct *isec = ipcp->security;
+-	*secid = isec->sid;
++	struct ipc_security_struct *isec = selinux_ipc(ipcp);
++
++	selinux_export_secid(l, isec->sid);
+ }
+ 
+ static void selinux_d_instantiate(struct dentry *dentry, struct inode *inode)
+@@ -6421,7 +6226,7 @@ static int selinux_getprocattr(struct task_struct *p,
+ 	unsigned len;
+ 
+ 	rcu_read_lock();
+-	__tsec = __task_cred(p)->security;
++	__tsec = selinux_cred(__task_cred(p));
+ 
+ 	if (current != p) {
+ 		error = avc_has_perm(&selinux_state,
+@@ -6544,18 +6349,17 @@ static int selinux_setprocattr(const char *name, void *value, size_t size)
+ 	   operation.  See selinux_bprm_set_creds for the execve
+ 	   checks and may_create for the file creation checks. The
+ 	   operation will then fail if the context is not permitted. */
+-	tsec = new->security;
++	tsec = selinux_cred(new);
+ 	if (!strcmp(name, "exec")) {
+ 		tsec->exec_sid = sid;
+ 	} else if (!strcmp(name, "fscreate")) {
+ 		tsec->create_sid = sid;
+ 	} else if (!strcmp(name, "keycreate")) {
+-		if (sid) {
+-			error = avc_has_perm(&selinux_state, mysid, sid,
+-					     SECCLASS_KEY, KEY__CREATE, NULL);
+-			if (error)
+-				goto abort_change;
+-		}
++		error = avc_has_perm(&selinux_state,
++				     mysid, sid, SECCLASS_KEY, KEY__CREATE,
++				     NULL);
++		if (error)
++			goto abort_change;
+ 		tsec->keycreate_sid = sid;
+ 	} else if (!strcmp(name, "sockcreate")) {
+ 		tsec->sockcreate_sid = sid;
+@@ -6610,26 +6414,34 @@ static int selinux_ismaclabel(const char *name)
+ 	return (strcmp(name, XATTR_SELINUX_SUFFIX) == 0);
+ }
+ 
+-static int selinux_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
++static int selinux_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp)
+ {
++	u32 secid;
++
++	selinux_import_secid(l, &secid);
++	cp->release = selinux_release_secctx;
++	if (l->flags & LSM_EXPORT_LENGTH)
++		return security_sid_to_context(&selinux_state, secid,
++					       NULL, &cp->len);
+ 	return security_sid_to_context(&selinux_state, secid,
+-				       secdata, seclen);
++				       &cp->context, &cp->len);
+ }
+ 
+-static int selinux_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
++static int selinux_secctx_to_secid(const struct lsm_context *cp,
++				   struct lsm_export *l)
+ {
+-	return security_context_to_sid(&selinux_state, secdata, seclen,
+-				       secid, GFP_KERNEL);
+-}
++	u32 secid;
++	int rc;
+ 
+-static void selinux_release_secctx(char *secdata, u32 seclen)
+-{
+-	kfree(secdata);
++	rc = security_context_to_sid(&selinux_state, cp->context, cp->len,
++				     &secid, GFP_KERNEL);
++	selinux_export_secid(l, secid);
++	return rc;
+ }
+ 
+ static void selinux_inode_invalidate_secctx(struct inode *inode)
+ {
+-	struct inode_security_struct *isec = inode->i_security;
++	struct inode_security_struct *isec = selinux_inode(inode);
+ 
+ 	spin_lock(&isec->lock);
+ 	isec->initialized = LABEL_INVALID;
+@@ -6639,30 +6451,32 @@ static void selinux_inode_invalidate_secctx(struct inode *inode)
+ /*
+  *	called with inode->i_mutex locked
+  */
+-static int selinux_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen)
++static int selinux_inode_notifysecctx(struct inode *inode,
++				      struct lsm_context *cp)
+ {
+-	int rc = selinux_inode_setsecurity(inode, XATTR_SELINUX_SUFFIX,
+-					   ctx, ctxlen, 0);
+-	/* Do not return error when suppressing label (SBLABEL_MNT not set). */
+-	return rc == -EOPNOTSUPP ? 0 : rc;
++	return selinux_inode_setsecurity(inode, XATTR_SELINUX_SUFFIX,
++						cp->context, cp->len, 0);
+ }
+ 
+ /*
+  *	called with inode->i_mutex locked
+  */
+-static int selinux_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen)
++static int selinux_inode_setsecctx(struct dentry *dentry,
++				   struct lsm_context *cp)
+ {
+-	return __vfs_setxattr_noperm(dentry, XATTR_NAME_SELINUX, ctx, ctxlen, 0);
++	return __vfs_setxattr_noperm(dentry, XATTR_NAME_SELINUX, cp->context,
++				     cp->len, 0);
+ }
+ 
+-static int selinux_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen)
++static int selinux_inode_getsecctx(struct inode *inode, struct lsm_context *cp)
+ {
+ 	int len = 0;
+ 	len = selinux_inode_getsecurity(inode, XATTR_SELINUX_SUFFIX,
+-						ctx, true);
++						(void **)&cp->context, true);
+ 	if (len < 0)
+ 		return len;
+-	*ctxlen = len;
++	cp->len = len;
++	cp->release = selinux_release_secctx;
+ 	return 0;
+ }
+ #ifdef CONFIG_KEYS
+@@ -6671,30 +6485,17 @@ static int selinux_key_alloc(struct key *k, const struct cred *cred,
+ 			     unsigned long flags)
+ {
+ 	const struct task_security_struct *tsec;
+-	struct key_security_struct *ksec;
+-
+-	ksec = kzalloc(sizeof(struct key_security_struct), GFP_KERNEL);
+-	if (!ksec)
+-		return -ENOMEM;
++	struct key_security_struct *ksec = selinux_key(k);
+ 
+-	tsec = cred->security;
++	tsec = selinux_cred(cred);
+ 	if (tsec->keycreate_sid)
+ 		ksec->sid = tsec->keycreate_sid;
+ 	else
+ 		ksec->sid = tsec->sid;
+ 
+-	k->security = ksec;
+ 	return 0;
+ }
+ 
+-static void selinux_key_free(struct key *k)
+-{
+-	struct key_security_struct *ksec = k->security;
+-
+-	k->security = NULL;
+-	kfree(ksec);
+-}
+-
+ static int selinux_key_permission(key_ref_t key_ref,
+ 				  const struct cred *cred,
+ 				  unsigned perm)
+@@ -6712,7 +6513,7 @@ static int selinux_key_permission(key_ref_t key_ref,
+ 	sid = cred_sid(cred);
+ 
+ 	key = key_ref_to_ptr(key_ref);
+-	ksec = key->security;
++	ksec = selinux_key(key);
+ 
+ 	return avc_has_perm(&selinux_state,
+ 			    sid, ksec->sid, SECCLASS_KEY, perm, NULL);
+@@ -6720,7 +6521,7 @@ static int selinux_key_permission(key_ref_t key_ref,
+ 
+ static int selinux_key_getsecurity(struct key *key, char **_buffer)
+ {
+-	struct key_security_struct *ksec = key->security;
++	struct key_security_struct *ksec = selinux_key(key);
+ 	char *context = NULL;
+ 	unsigned len;
+ 	int rc;
+@@ -6940,6 +6741,19 @@ static void selinux_bpf_prog_free(struct bpf_prog_aux *aux)
+ }
+ #endif
+ 
++struct lsm_blob_sizes selinux_blob_sizes __lsm_ro_after_init = {
++	.lbs_cred = sizeof(struct task_security_struct),
++	.lbs_file = sizeof(struct file_security_struct),
++	.lbs_inode = sizeof(struct inode_security_struct),
++	.lbs_ipc = sizeof(struct ipc_security_struct),
++#ifdef CONFIG_KEYS
++	.lbs_key = sizeof(struct key_security_struct),
++#endif /* CONFIG_KEYS */
++	.lbs_msg_msg = sizeof(struct msg_security_struct),
++	.lbs_sock = sizeof(struct sk_security_struct),
++	.lbs_superblock = sizeof(struct superblock_security_struct),
++};
++
+ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(binder_set_context_mgr, selinux_binder_set_context_mgr),
+ 	LSM_HOOK_INIT(binder_transaction, selinux_binder_transaction),
+@@ -6963,7 +6777,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(bprm_committed_creds, selinux_bprm_committed_creds),
+ 
+ 	LSM_HOOK_INIT(sb_alloc_security, selinux_sb_alloc_security),
+-	LSM_HOOK_INIT(sb_free_security, selinux_sb_free_security),
+ 	LSM_HOOK_INIT(sb_copy_data, selinux_sb_copy_data),
+ 	LSM_HOOK_INIT(sb_remount, selinux_sb_remount),
+ 	LSM_HOOK_INIT(sb_kern_mount, selinux_sb_kern_mount),
+@@ -7008,7 +6821,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 
+ 	LSM_HOOK_INIT(file_permission, selinux_file_permission),
+ 	LSM_HOOK_INIT(file_alloc_security, selinux_file_alloc_security),
+-	LSM_HOOK_INIT(file_free_security, selinux_file_free_security),
+ 	LSM_HOOK_INIT(file_ioctl, selinux_file_ioctl),
+ 	LSM_HOOK_INIT(mmap_file, selinux_mmap_file),
+ 	LSM_HOOK_INIT(mmap_addr, selinux_mmap_addr),
+@@ -7022,8 +6834,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(file_open, selinux_file_open),
+ 
+ 	LSM_HOOK_INIT(task_alloc, selinux_task_alloc),
+-	LSM_HOOK_INIT(cred_alloc_blank, selinux_cred_alloc_blank),
+-	LSM_HOOK_INIT(cred_free, selinux_cred_free),
+ 	LSM_HOOK_INIT(cred_prepare, selinux_cred_prepare),
+ 	LSM_HOOK_INIT(cred_transfer, selinux_cred_transfer),
+ 	LSM_HOOK_INIT(cred_getsecid, selinux_cred_getsecid),
+@@ -7051,24 +6861,20 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(ipc_getsecid, selinux_ipc_getsecid),
+ 
+ 	LSM_HOOK_INIT(msg_msg_alloc_security, selinux_msg_msg_alloc_security),
+-	LSM_HOOK_INIT(msg_msg_free_security, selinux_msg_msg_free_security),
+ 
+ 	LSM_HOOK_INIT(msg_queue_alloc_security,
+ 			selinux_msg_queue_alloc_security),
+-	LSM_HOOK_INIT(msg_queue_free_security, selinux_msg_queue_free_security),
+ 	LSM_HOOK_INIT(msg_queue_associate, selinux_msg_queue_associate),
+ 	LSM_HOOK_INIT(msg_queue_msgctl, selinux_msg_queue_msgctl),
+ 	LSM_HOOK_INIT(msg_queue_msgsnd, selinux_msg_queue_msgsnd),
+ 	LSM_HOOK_INIT(msg_queue_msgrcv, selinux_msg_queue_msgrcv),
+ 
+ 	LSM_HOOK_INIT(shm_alloc_security, selinux_shm_alloc_security),
+-	LSM_HOOK_INIT(shm_free_security, selinux_shm_free_security),
+ 	LSM_HOOK_INIT(shm_associate, selinux_shm_associate),
+ 	LSM_HOOK_INIT(shm_shmctl, selinux_shm_shmctl),
+ 	LSM_HOOK_INIT(shm_shmat, selinux_shm_shmat),
+ 
+ 	LSM_HOOK_INIT(sem_alloc_security, selinux_sem_alloc_security),
+-	LSM_HOOK_INIT(sem_free_security, selinux_sem_free_security),
+ 	LSM_HOOK_INIT(sem_associate, selinux_sem_associate),
+ 	LSM_HOOK_INIT(sem_semctl, selinux_sem_semctl),
+ 	LSM_HOOK_INIT(sem_semop, selinux_sem_semop),
+@@ -7081,7 +6887,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(ismaclabel, selinux_ismaclabel),
+ 	LSM_HOOK_INIT(secid_to_secctx, selinux_secid_to_secctx),
+ 	LSM_HOOK_INIT(secctx_to_secid, selinux_secctx_to_secid),
+-	LSM_HOOK_INIT(release_secctx, selinux_release_secctx),
+ 	LSM_HOOK_INIT(inode_invalidate_secctx, selinux_inode_invalidate_secctx),
+ 	LSM_HOOK_INIT(inode_notifysecctx, selinux_inode_notifysecctx),
+ 	LSM_HOOK_INIT(inode_setsecctx, selinux_inode_setsecctx),
+@@ -7154,7 +6959,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 
+ #ifdef CONFIG_KEYS
+ 	LSM_HOOK_INIT(key_alloc, selinux_key_alloc),
+-	LSM_HOOK_INIT(key_free, selinux_key_free),
+ 	LSM_HOOK_INIT(key_permission, selinux_key_permission),
+ 	LSM_HOOK_INIT(key_getsecurity, selinux_key_getsecurity),
+ #endif
+@@ -7179,16 +6983,6 @@ static struct security_hook_list selinux_hooks[] __lsm_ro_after_init = {
+ 
+ static __init int selinux_init(void)
+ {
+-	if (!security_module_enable("selinux")) {
+-		selinux_enabled = 0;
+-		return 0;
+-	}
+-
+-	if (!selinux_enabled) {
+-		pr_info("SELinux:  Disabled at boot.\n");
+-		return 0;
+-	}
+-
+ 	pr_info("SELinux:  Initializing.\n");
+ 
+ 	memset(&selinux_state, 0, sizeof(selinux_state));
+@@ -7202,12 +6996,6 @@ static __init int selinux_init(void)
+ 
+ 	default_noexec = !(VM_DATA_DEFAULT_FLAGS & VM_EXEC);
+ 
+-	sel_inode_cache = kmem_cache_create("selinux_inode_security",
+-					    sizeof(struct inode_security_struct),
+-					    0, SLAB_PANIC, NULL);
+-	file_security_cache = kmem_cache_create("selinux_file_security",
+-					    sizeof(struct file_security_struct),
+-					    0, SLAB_PANIC, NULL);
+ 	avc_init();
+ 
+ 	avtab_cache_init();
+@@ -7248,7 +7036,13 @@ void selinux_complete_init(void)
+ 
+ /* SELinux requires early initialization in order to label
+    all processes and objects when they are created. */
+-security_initcall(selinux_init);
++DEFINE_LSM(selinux) = {
++	.name = "selinux",
++	.flags = LSM_FLAG_LEGACY_MAJOR | LSM_FLAG_EXCLUSIVE,
++	.enabled = &selinux_enabled,
++	.blobs = &selinux_blob_sizes,
++	.init = selinux_init,
++};
+ 
+ #if defined(CONFIG_NETFILTER)
+ 
+diff --git a/security/selinux/include/audit.h b/security/selinux/include/audit.h
+index 1bdf973433cc..7daa44d188f7 100644
+--- a/security/selinux/include/audit.h
++++ b/security/selinux/include/audit.h
+@@ -1,9 +1,6 @@
+ /*
+  * SELinux support for the Audit LSM hooks
+  *
+- * Most of below header was moved from include/linux/selinux.h which
+- * is released under below copyrights:
+- *
+  * Author: James Morris <jmorris@redhat.com>
+  *
+  * Copyright (C) 2005 Red Hat, Inc., James Morris <jmorris@redhat.com>
+@@ -42,7 +39,7 @@ void selinux_audit_rule_free(void *rule);
+ 
+ /**
+  *	selinux_audit_rule_match - determine if a context ID matches a rule.
+- *	@sid: the context ID to check
++ *	@l: points to the context ID to check
+  *	@field: the field this rule refers to
+  *	@op: the operater the rule uses
+  *	@rule: pointer to the audit rule to check against
+@@ -51,8 +48,8 @@ void selinux_audit_rule_free(void *rule);
+  *	Returns 1 if the context id matches the rule, 0 if it does not, and
+  *	-errno on failure.
+  */
+-int selinux_audit_rule_match(u32 sid, u32 field, u32 op, void *rule,
+-			     struct audit_context *actx);
++int selinux_audit_rule_match(struct lsm_export *l, u32 field, u32 op,
++			     void *rule, struct audit_context *actx);
+ 
+ /**
+  *	selinux_audit_rule_known - check to see if rule contains selinux fields.
+diff --git a/security/selinux/include/avc.h b/security/selinux/include/avc.h
+index 74ea50977c20..ef899bcfd2cb 100644
+--- a/security/selinux/include/avc.h
++++ b/security/selinux/include/avc.h
+@@ -142,7 +142,6 @@ static inline int avc_audit(struct selinux_state *state,
+ 
+ #define AVC_STRICT 1 /* Ignore permissive mode. */
+ #define AVC_EXTENDED_PERMS 2	/* update extended permissions */
+-#define AVC_NONBLOCKING    4	/* non blocking */
+ int avc_has_perm_noaudit(struct selinux_state *state,
+ 			 u32 ssid, u32 tsid,
+ 			 u16 tclass, u32 requested,
+diff --git a/security/selinux/include/classmap.h b/security/selinux/include/classmap.h
+index 201f7e588a29..bd5fe0d3204a 100644
+--- a/security/selinux/include/classmap.h
++++ b/security/selinux/include/classmap.h
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
+ #include <linux/capability.h>
+-#include <linux/socket.h>
+ 
+ #define COMMON_FILE_SOCK_PERMS "ioctl", "read", "write", "create", \
+     "getattr", "setattr", "lock", "relabelfrom", "relabelto", "append", "map"
+diff --git a/security/selinux/include/objsec.h b/security/selinux/include/objsec.h
+index cc5e26b0161b..c9a88b7a96a7 100644
+--- a/security/selinux/include/objsec.h
++++ b/security/selinux/include/objsec.h
+@@ -25,10 +25,14 @@
+ #include <linux/binfmts.h>
+ #include <linux/in.h>
+ #include <linux/spinlock.h>
++#include <linux/lsm_hooks.h>
++#include <linux/msg.h>
+ #include <net/net_namespace.h>
+ #include "flask.h"
+ #include "avc.h"
+ 
++extern struct lsm_blob_sizes selinux_blob_sizes;
++
+ struct task_security_struct {
+ 	u32 osid;		/* SID prior to last execve */
+ 	u32 sid;		/* current SID */
+@@ -43,11 +47,30 @@ struct task_security_struct {
+  */
+ static inline u32 current_sid(void)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec;
++
++	tsec = current_cred()->security + selinux_blob_sizes.lbs_cred;
+ 
+ 	return tsec->sid;
+ }
+ 
++/*
++ * Set the SELinux secid in an lsm_export structure
++ */
++static inline void selinux_export_secid(struct lsm_export *l, u32 secid)
++{
++	l->selinux = secid;
++	l->flags |= LSM_EXPORT_SELINUX;
++}
++
++static inline void selinux_import_secid(struct lsm_export *l, u32 *secid)
++{
++	if (l->flags & LSM_EXPORT_SELINUX)
++		*secid = l->selinux;
++	else
++		*secid = SECSID_NULL;
++}
++
+ enum label_initialized {
+ 	LABEL_INVALID,		/* invalid or not initialized */
+ 	LABEL_INITIALIZED,	/* initialized */
+@@ -56,10 +79,7 @@ enum label_initialized {
+ 
+ struct inode_security_struct {
+ 	struct inode *inode;	/* back pointer to inode object */
+-	union {
+-		struct list_head list;	/* list of inode_security_struct */
+-		struct rcu_head rcu;	/* for freeing the inode_security_struct */
+-	};
++	struct list_head list;	/* list of inode_security_struct */
+ 	u32 task_sid;		/* SID of creating task */
+ 	u32 sid;		/* SID of this object */
+ 	u16 sclass;		/* security class of this object */
+@@ -158,4 +178,52 @@ struct bpf_security_struct {
+ 	u32 sid;  /*SID of bpf obj creater*/
+ };
+ 
++static inline struct task_security_struct *selinux_cred(const struct cred *cred)
++{
++	return cred->security + selinux_blob_sizes.lbs_cred;
++}
++
++static inline struct file_security_struct *selinux_file(const struct file *file)
++{
++	return file->f_security + selinux_blob_sizes.lbs_file;
++}
++
++static inline struct inode_security_struct *selinux_inode(
++						const struct inode *inode)
++{
++	if (unlikely(!inode->i_security))
++		return NULL;
++	return inode->i_security + selinux_blob_sizes.lbs_inode;
++}
++
++static inline struct msg_security_struct *selinux_msg_msg(
++						const struct msg_msg *msg_msg)
++{
++	return msg_msg->security + selinux_blob_sizes.lbs_msg_msg;
++}
++
++static inline struct ipc_security_struct *selinux_ipc(
++						const struct kern_ipc_perm *ipc)
++{
++	return ipc->security + selinux_blob_sizes.lbs_ipc;
++}
++
++static inline struct superblock_security_struct *selinux_superblock(
++					const struct super_block *superblock)
++{
++	return superblock->s_security + selinux_blob_sizes.lbs_superblock;
++}
++
++#ifdef CONFIG_KEYS
++static inline struct key_security_struct *selinux_key(const struct key *key)
++{
++	return key->security + selinux_blob_sizes.lbs_key;
++}
++#endif /* CONFIG_KEYS */
++
++static inline struct sk_security_struct *selinux_sock(const struct sock *sock)
++{
++	return sock->sk_security + selinux_blob_sizes.lbs_sock;
++}
++
+ #endif /* _SELINUX_OBJSEC_H_ */
+diff --git a/security/selinux/netlabel.c b/security/selinux/netlabel.c
+index 6fd9954e1c08..4bbd50237a8a 100644
+--- a/security/selinux/netlabel.c
++++ b/security/selinux/netlabel.c
+@@ -31,6 +31,7 @@
+ #include <linux/gfp.h>
+ #include <linux/ip.h>
+ #include <linux/ipv6.h>
++#include <linux/lsm_hooks.h>
+ #include <net/sock.h>
+ #include <net/netlabel.h>
+ #include <net/ip.h>
+@@ -81,7 +82,7 @@ static int selinux_netlbl_sidlookup_cached(struct sk_buff *skb,
+ static struct netlbl_lsm_secattr *selinux_netlbl_sock_genattr(struct sock *sk)
+ {
+ 	int rc;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct netlbl_lsm_secattr *secattr;
+ 
+ 	if (sksec->nlbl_secattr != NULL)
+@@ -114,14 +115,14 @@ static struct netlbl_lsm_secattr *selinux_netlbl_sock_getattr(
+ 							const struct sock *sk,
+ 							u32 sid)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct netlbl_lsm_secattr *secattr = sksec->nlbl_secattr;
+ 
+ 	if (secattr == NULL)
+ 		return NULL;
+ 
+ 	if ((secattr->flags & NETLBL_SECATTR_SECID) &&
+-	    (secattr->attr.secid == sid))
++	    (secattr->attr.le.selinux == sid))
+ 		return secattr;
+ 
+ 	return NULL;
+@@ -249,7 +250,7 @@ int selinux_netlbl_skbuff_setsid(struct sk_buff *skb,
+ 	 * being labeled by it's parent socket, if it is just exit */
+ 	sk = skb_to_full_sk(skb);
+ 	if (sk != NULL) {
+-		struct sk_security_struct *sksec = sk->sk_security;
++		struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 		if (sksec->nlbl_state != NLBL_REQSKB)
+ 			return 0;
+@@ -287,9 +288,12 @@ int selinux_netlbl_sctp_assoc_request(struct sctp_endpoint *ep,
+ {
+ 	int rc;
+ 	struct netlbl_lsm_secattr secattr;
+-	struct sk_security_struct *sksec = ep->base.sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(ep->base.sk);
++	struct sockaddr *addr;
+ 	struct sockaddr_in addr4;
++#if IS_ENABLED(CONFIG_IPV6)
+ 	struct sockaddr_in6 addr6;
++#endif
+ 
+ 	if (ep->base.sk->sk_family != PF_INET &&
+ 				ep->base.sk->sk_family != PF_INET6)
+@@ -307,15 +311,16 @@ int selinux_netlbl_sctp_assoc_request(struct sctp_endpoint *ep,
+ 	if (ip_hdr(skb)->version == 4) {
+ 		addr4.sin_family = AF_INET;
+ 		addr4.sin_addr.s_addr = ip_hdr(skb)->saddr;
+-		rc = netlbl_conn_setattr(ep->base.sk, (void *)&addr4, &secattr);
+-	} else if (IS_ENABLED(CONFIG_IPV6) && ip_hdr(skb)->version == 6) {
++		addr = (struct sockaddr *)&addr4;
++#if IS_ENABLED(CONFIG_IPV6)
++	} else {
+ 		addr6.sin6_family = AF_INET6;
+ 		addr6.sin6_addr = ipv6_hdr(skb)->saddr;
+-		rc = netlbl_conn_setattr(ep->base.sk, (void *)&addr6, &secattr);
+-	} else {
+-		rc = -EAFNOSUPPORT;
++		addr = (struct sockaddr *)&addr6;
++#endif
+ 	}
+ 
++	rc = netlbl_conn_setattr(ep->base.sk, addr, &secattr);
+ 	if (rc == 0)
+ 		sksec->nlbl_state = NLBL_LABELED;
+ 
+@@ -366,7 +371,7 @@ int selinux_netlbl_inet_conn_request(struct request_sock *req, u16 family)
+  */
+ void selinux_netlbl_inet_csk_clone(struct sock *sk, u16 family)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	if (family == PF_INET)
+ 		sksec->nlbl_state = NLBL_LABELED;
+@@ -384,8 +389,8 @@ void selinux_netlbl_inet_csk_clone(struct sock *sk, u16 family)
+  */
+ void selinux_netlbl_sctp_sk_clone(struct sock *sk, struct sock *newsk)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
+-	struct sk_security_struct *newsksec = newsk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
++	struct sk_security_struct *newsksec = selinux_sock(newsk);
+ 
+ 	newsksec->nlbl_state = sksec->nlbl_state;
+ }
+@@ -403,7 +408,7 @@ void selinux_netlbl_sctp_sk_clone(struct sock *sk, struct sock *newsk)
+ int selinux_netlbl_socket_post_create(struct sock *sk, u16 family)
+ {
+ 	int rc;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct netlbl_lsm_secattr *secattr;
+ 
+ 	if (family != PF_INET && family != PF_INET6)
+@@ -518,7 +523,7 @@ int selinux_netlbl_socket_setsockopt(struct socket *sock,
+ {
+ 	int rc = 0;
+ 	struct sock *sk = sock->sk;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct netlbl_lsm_secattr secattr;
+ 
+ 	if (selinux_netlbl_option(level, optname) &&
+@@ -556,7 +561,7 @@ static int selinux_netlbl_socket_connect_helper(struct sock *sk,
+ 						struct sockaddr *addr)
+ {
+ 	int rc;
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 	struct netlbl_lsm_secattr *secattr;
+ 
+ 	/* connected sockets are allowed to disconnect when the address family
+@@ -595,7 +600,7 @@ static int selinux_netlbl_socket_connect_helper(struct sock *sk,
+ int selinux_netlbl_socket_connect_locked(struct sock *sk,
+ 					 struct sockaddr *addr)
+ {
+-	struct sk_security_struct *sksec = sk->sk_security;
++	struct sk_security_struct *sksec = selinux_sock(sk);
+ 
+ 	if (sksec->nlbl_state != NLBL_REQSKB &&
+ 	    sksec->nlbl_state != NLBL_CONNLABELED)
+diff --git a/security/selinux/nlmsgtab.c b/security/selinux/nlmsgtab.c
+index 9cec81209617..74b951f55608 100644
+--- a/security/selinux/nlmsgtab.c
++++ b/security/selinux/nlmsgtab.c
+@@ -80,9 +80,6 @@ static const struct nlmsg_perm nlmsg_route_perms[] =
+ 	{ RTM_NEWSTATS,		NETLINK_ROUTE_SOCKET__NLMSG_READ },
+ 	{ RTM_GETSTATS,		NETLINK_ROUTE_SOCKET__NLMSG_READ  },
+ 	{ RTM_NEWCACHEREPORT,	NETLINK_ROUTE_SOCKET__NLMSG_READ },
+-	{ RTM_NEWCHAIN,		NETLINK_ROUTE_SOCKET__NLMSG_WRITE },
+-	{ RTM_DELCHAIN,		NETLINK_ROUTE_SOCKET__NLMSG_WRITE },
+-	{ RTM_GETCHAIN,		NETLINK_ROUTE_SOCKET__NLMSG_READ  },
+ };
+ 
+ static const struct nlmsg_perm nlmsg_tcpdiag_perms[] =
+@@ -161,11 +158,7 @@ int selinux_nlmsg_lookup(u16 sclass, u16 nlmsg_type, u32 *perm)
+ 
+ 	switch (sclass) {
+ 	case SECCLASS_NETLINK_ROUTE_SOCKET:
+-		/* RTM_MAX always points to RTM_SETxxxx, ie RTM_NEWxxx + 3.
+-		 * If the BUILD_BUG_ON() below fails you must update the
+-		 * structures at the top of this file with the new mappings
+-		 * before updating the BUILD_BUG_ON() macro!
+-		 */
++		/* RTM_MAX always point to RTM_SETxxxx, ie RTM_NEWxxx + 3 */
+ 		BUILD_BUG_ON(RTM_MAX != (RTM_NEWCHAIN + 3));
+ 		err = nlmsg_perm(nlmsg_type, perm, nlmsg_route_perms,
+ 				 sizeof(nlmsg_route_perms));
+@@ -177,10 +170,6 @@ int selinux_nlmsg_lookup(u16 sclass, u16 nlmsg_type, u32 *perm)
+ 		break;
+ 
+ 	case SECCLASS_NETLINK_XFRM_SOCKET:
+-		/* If the BUILD_BUG_ON() below fails you must update the
+-		 * structures at the top of this file with the new mappings
+-		 * before updating the BUILD_BUG_ON() macro!
+-		 */
+ 		BUILD_BUG_ON(XFRM_MSG_MAX != XFRM_MSG_MAPPING);
+ 		err = nlmsg_perm(nlmsg_type, perm, nlmsg_xfrm_perms,
+ 				 sizeof(nlmsg_xfrm_perms));
+diff --git a/security/selinux/selinuxfs.c b/security/selinux/selinuxfs.c
+index f3a5a138a096..145ee62f205a 100644
+--- a/security/selinux/selinuxfs.c
++++ b/security/selinux/selinuxfs.c
+@@ -1378,7 +1378,7 @@ static int sel_make_bools(struct selinux_fs_info *fsi)
+ 			goto out;
+ 		}
+ 
+-		isec = (struct inode_security_struct *)inode->i_security;
++		isec = selinux_inode(inode);
+ 		ret = security_genfs_sid(fsi->state, "selinuxfs", page,
+ 					 SECCLASS_FILE, &sid);
+ 		if (ret) {
+@@ -1953,7 +1953,7 @@ static int sel_fill_super(struct super_block *sb, void *data, int silent)
+ 	}
+ 
+ 	inode->i_ino = ++fsi->last_ino;
+-	isec = (struct inode_security_struct *)inode->i_security;
++	isec = selinux_inode(inode);
+ 	isec->sid = SECINITSID_DEVNULL;
+ 	isec->sclass = SECCLASS_CHR_FILE;
+ 	isec->initialized = LABEL_INITIALIZED;
+diff --git a/security/selinux/ss/mls.c b/security/selinux/ss/mls.c
+index 39475fb455bc..2fe459df3c85 100644
+--- a/security/selinux/ss/mls.c
++++ b/security/selinux/ss/mls.c
+@@ -218,9 +218,7 @@ int mls_context_isvalid(struct policydb *p, struct context *c)
+ /*
+  * Set the MLS fields in the security context structure
+  * `context' based on the string representation in
+- * the string `*scontext'.  Update `*scontext' to
+- * point to the end of the string representation of
+- * the MLS fields.
++ * the string `scontext'.
+  *
+  * This function modifies the string in place, inserting
+  * NULL characters to terminate the MLS fields.
+@@ -235,22 +233,21 @@ int mls_context_isvalid(struct policydb *p, struct context *c)
+  */
+ int mls_context_to_sid(struct policydb *pol,
+ 		       char oldc,
+-		       char **scontext,
++		       char *scontext,
+ 		       struct context *context,
+ 		       struct sidtab *s,
+ 		       u32 def_sid)
+ {
+-
+-	char delim;
+-	char *scontextp, *p, *rngptr;
++	char *sensitivity, *cur_cat, *next_cat, *rngptr;
+ 	struct level_datum *levdatum;
+ 	struct cat_datum *catdatum, *rngdatum;
+-	int l, rc = -EINVAL;
++	int l, rc, i;
++	char *rangep[2];
+ 
+ 	if (!pol->mls_enabled) {
+-		if (def_sid != SECSID_NULL && oldc)
+-			*scontext += strlen(*scontext) + 1;
+-		return 0;
++		if ((def_sid != SECSID_NULL && oldc) || (*scontext) == '\0')
++			return 0;
++		return -EINVAL;
+ 	}
+ 
+ 	/*
+@@ -261,113 +258,94 @@ int mls_context_to_sid(struct policydb *pol,
+ 		struct context *defcon;
+ 
+ 		if (def_sid == SECSID_NULL)
+-			goto out;
++			return -EINVAL;
+ 
+ 		defcon = sidtab_search(s, def_sid);
+ 		if (!defcon)
+-			goto out;
++			return -EINVAL;
+ 
+-		rc = mls_context_cpy(context, defcon);
+-		goto out;
++		return mls_context_cpy(context, defcon);
+ 	}
+ 
+-	/* Extract low sensitivity. */
+-	scontextp = p = *scontext;
+-	while (*p && *p != ':' && *p != '-')
+-		p++;
+-
+-	delim = *p;
+-	if (delim != '\0')
+-		*p++ = '\0';
++	/*
++	 * If we're dealing with a range, figure out where the two parts
++	 * of the range begin.
++	 */
++	rangep[0] = scontext;
++	rangep[1] = strchr(scontext, '-');
++	if (rangep[1]) {
++		rangep[1][0] = '\0';
++		rangep[1]++;
++	}
+ 
++	/* For each part of the range: */
+ 	for (l = 0; l < 2; l++) {
+-		levdatum = hashtab_search(pol->p_levels.table, scontextp);
+-		if (!levdatum) {
+-			rc = -EINVAL;
+-			goto out;
+-		}
++		/* Split sensitivity and category set. */
++		sensitivity = rangep[l];
++		if (sensitivity == NULL)
++			break;
++		next_cat = strchr(sensitivity, ':');
++		if (next_cat)
++			*(next_cat++) = '\0';
+ 
++		/* Parse sensitivity. */
++		levdatum = hashtab_search(pol->p_levels.table, sensitivity);
++		if (!levdatum)
++			return -EINVAL;
+ 		context->range.level[l].sens = levdatum->level->sens;
+ 
+-		if (delim == ':') {
+-			/* Extract category set. */
+-			while (1) {
+-				scontextp = p;
+-				while (*p && *p != ',' && *p != '-')
+-					p++;
+-				delim = *p;
+-				if (delim != '\0')
+-					*p++ = '\0';
+-
+-				/* Separate into range if exists */
+-				rngptr = strchr(scontextp, '.');
+-				if (rngptr != NULL) {
+-					/* Remove '.' */
+-					*rngptr++ = '\0';
+-				}
++		/* Extract category set. */
++		while (next_cat != NULL) {
++			cur_cat = next_cat;
++			next_cat = strchr(next_cat, ',');
++			if (next_cat != NULL)
++				*(next_cat++) = '\0';
++
++			/* Separate into range if exists */
++			rngptr = strchr(cur_cat, '.');
++			if (rngptr != NULL) {
++				/* Remove '.' */
++				*rngptr++ = '\0';
++			}
+ 
+-				catdatum = hashtab_search(pol->p_cats.table,
+-							  scontextp);
+-				if (!catdatum) {
+-					rc = -EINVAL;
+-					goto out;
+-				}
++			catdatum = hashtab_search(pol->p_cats.table, cur_cat);
++			if (!catdatum)
++				return -EINVAL;
+ 
+-				rc = ebitmap_set_bit(&context->range.level[l].cat,
+-						     catdatum->value - 1, 1);
+-				if (rc)
+-					goto out;
+-
+-				/* If range, set all categories in range */
+-				if (rngptr) {
+-					int i;
+-
+-					rngdatum = hashtab_search(pol->p_cats.table, rngptr);
+-					if (!rngdatum) {
+-						rc = -EINVAL;
+-						goto out;
+-					}
+-
+-					if (catdatum->value >= rngdatum->value) {
+-						rc = -EINVAL;
+-						goto out;
+-					}
+-
+-					for (i = catdatum->value; i < rngdatum->value; i++) {
+-						rc = ebitmap_set_bit(&context->range.level[l].cat, i, 1);
+-						if (rc)
+-							goto out;
+-					}
+-				}
++			rc = ebitmap_set_bit(&context->range.level[l].cat,
++					     catdatum->value - 1, 1);
++			if (rc)
++				return rc;
++
++			/* If range, set all categories in range */
++			if (rngptr == NULL)
++				continue;
++
++			rngdatum = hashtab_search(pol->p_cats.table, rngptr);
++			if (!rngdatum)
++				return -EINVAL;
++
++			if (catdatum->value >= rngdatum->value)
++				return -EINVAL;
+ 
+-				if (delim != ',')
+-					break;
++			for (i = catdatum->value; i < rngdatum->value; i++) {
++				rc = ebitmap_set_bit(&context->range.level[l].cat, i, 1);
++				if (rc)
++					return rc;
+ 			}
+ 		}
+-		if (delim == '-') {
+-			/* Extract high sensitivity. */
+-			scontextp = p;
+-			while (*p && *p != ':')
+-				p++;
+-
+-			delim = *p;
+-			if (delim != '\0')
+-				*p++ = '\0';
+-		} else
+-			break;
+ 	}
+ 
+-	if (l == 0) {
++	/* If we didn't see a '-', the range start is also the range end. */
++	if (rangep[1] == NULL) {
+ 		context->range.level[1].sens = context->range.level[0].sens;
+ 		rc = ebitmap_cpy(&context->range.level[1].cat,
+ 				 &context->range.level[0].cat);
+ 		if (rc)
+-			goto out;
++			return rc;
+ 	}
+-	*scontext = ++p;
+-	rc = 0;
+-out:
+-	return rc;
++
++	return 0;
+ }
+ 
+ /*
+@@ -379,21 +357,19 @@ int mls_context_to_sid(struct policydb *pol,
+ int mls_from_string(struct policydb *p, char *str, struct context *context,
+ 		    gfp_t gfp_mask)
+ {
+-	char *tmpstr, *freestr;
++	char *tmpstr;
+ 	int rc;
+ 
+ 	if (!p->mls_enabled)
+ 		return -EINVAL;
+ 
+-	/* we need freestr because mls_context_to_sid will change
+-	   the value of tmpstr */
+-	tmpstr = freestr = kstrdup(str, gfp_mask);
++	tmpstr = kstrdup(str, gfp_mask);
+ 	if (!tmpstr) {
+ 		rc = -ENOMEM;
+ 	} else {
+-		rc = mls_context_to_sid(p, ':', &tmpstr, context,
++		rc = mls_context_to_sid(p, ':', tmpstr, context,
+ 					NULL, SECSID_NULL);
+-		kfree(freestr);
++		kfree(tmpstr);
+ 	}
+ 
+ 	return rc;
+diff --git a/security/selinux/ss/mls.h b/security/selinux/ss/mls.h
+index 9a3ff7af70ad..67093647576d 100644
+--- a/security/selinux/ss/mls.h
++++ b/security/selinux/ss/mls.h
+@@ -34,7 +34,7 @@ int mls_level_isvalid(struct policydb *p, struct mls_level *l);
+ 
+ int mls_context_to_sid(struct policydb *p,
+ 		       char oldc,
+-		       char **scontext,
++		       char *scontext,
+ 		       struct context *context,
+ 		       struct sidtab *s,
+ 		       u32 def_sid);
+diff --git a/security/selinux/ss/policydb.c b/security/selinux/ss/policydb.c
+index 91d259c87d10..f4eadd3f7350 100644
+--- a/security/selinux/ss/policydb.c
++++ b/security/selinux/ss/policydb.c
+@@ -275,8 +275,6 @@ static int rangetr_cmp(struct hashtab *h, const void *k1, const void *k2)
+ 	return v;
+ }
+ 
+-static int (*destroy_f[SYM_NUM]) (void *key, void *datum, void *datap);
+-
+ /*
+  * Initialize a policy database structure.
+  */
+@@ -324,10 +322,8 @@ static int policydb_init(struct policydb *p)
+ out:
+ 	hashtab_destroy(p->filename_trans);
+ 	hashtab_destroy(p->range_tr);
+-	for (i = 0; i < SYM_NUM; i++) {
+-		hashtab_map(p->symtab[i].table, destroy_f[i], NULL);
++	for (i = 0; i < SYM_NUM; i++)
+ 		hashtab_destroy(p->symtab[i].table);
+-	}
+ 	return rc;
+ }
+ 
+@@ -736,8 +732,7 @@ static int sens_destroy(void *key, void *datum, void *p)
+ 	kfree(key);
+ 	if (datum) {
+ 		levdatum = datum;
+-		if (levdatum->level)
+-			ebitmap_destroy(&levdatum->level->cat);
++		ebitmap_destroy(&levdatum->level->cat);
+ 		kfree(levdatum->level);
+ 	}
+ 	kfree(datum);
+@@ -2113,7 +2108,6 @@ static int ocontext_read(struct policydb *p, struct policydb_compat_info *info,
+ {
+ 	int i, j, rc;
+ 	u32 nel, len;
+-	__be64 prefixbuf[1];
+ 	__le32 buf[3];
+ 	struct ocontext *l, *c;
+ 	u32 nodebuf[8];
+@@ -2223,30 +2217,21 @@ static int ocontext_read(struct policydb *p, struct policydb_compat_info *info,
+ 					goto out;
+ 				break;
+ 			}
+-			case OCON_IBPKEY: {
+-				u32 pkey_lo, pkey_hi;
+-
+-				rc = next_entry(prefixbuf, fp, sizeof(u64));
+-				if (rc)
+-					goto out;
+-
+-				/* we need to have subnet_prefix in CPU order */
+-				c->u.ibpkey.subnet_prefix = be64_to_cpu(prefixbuf[0]);
+-
+-				rc = next_entry(buf, fp, sizeof(u32) * 2);
++			case OCON_IBPKEY:
++				rc = next_entry(nodebuf, fp, sizeof(u32) * 4);
+ 				if (rc)
+ 					goto out;
+ 
+-				pkey_lo = le32_to_cpu(buf[0]);
+-				pkey_hi = le32_to_cpu(buf[1]);
++				c->u.ibpkey.subnet_prefix = be64_to_cpu(*((__be64 *)nodebuf));
+ 
+-				if (pkey_lo > U16_MAX || pkey_hi > U16_MAX) {
++				if (nodebuf[2] > 0xffff ||
++				    nodebuf[3] > 0xffff) {
+ 					rc = -EINVAL;
+ 					goto out;
+ 				}
+ 
+-				c->u.ibpkey.low_pkey  = pkey_lo;
+-				c->u.ibpkey.high_pkey = pkey_hi;
++				c->u.ibpkey.low_pkey = le32_to_cpu(nodebuf[2]);
++				c->u.ibpkey.high_pkey = le32_to_cpu(nodebuf[3]);
+ 
+ 				rc = context_read_and_validate(&c->context[0],
+ 							       p,
+@@ -2254,10 +2239,7 @@ static int ocontext_read(struct policydb *p, struct policydb_compat_info *info,
+ 				if (rc)
+ 					goto out;
+ 				break;
+-			}
+-			case OCON_IBENDPORT: {
+-				u32 port;
+-
++			case OCON_IBENDPORT:
+ 				rc = next_entry(buf, fp, sizeof(u32) * 2);
+ 				if (rc)
+ 					goto out;
+@@ -2267,13 +2249,12 @@ static int ocontext_read(struct policydb *p, struct policydb_compat_info *info,
+ 				if (rc)
+ 					goto out;
+ 
+-				port = le32_to_cpu(buf[1]);
+-				if (port > U8_MAX || port == 0) {
++				if (buf[1] > 0xff || buf[1] == 0) {
+ 					rc = -EINVAL;
+ 					goto out;
+ 				}
+ 
+-				c->u.ibendport.port = port;
++				c->u.ibendport.port = le32_to_cpu(buf[1]);
+ 
+ 				rc = context_read_and_validate(&c->context[0],
+ 							       p,
+@@ -2281,8 +2262,7 @@ static int ocontext_read(struct policydb *p, struct policydb_compat_info *info,
+ 				if (rc)
+ 					goto out;
+ 				break;
+-			} /* end case */
+-			} /* end switch */
++			}
+ 		}
+ 	}
+ 	rc = 0;
+@@ -3125,7 +3105,6 @@ static int ocontext_write(struct policydb *p, struct policydb_compat_info *info,
+ {
+ 	unsigned int i, j, rc;
+ 	size_t nel, len;
+-	__be64 prefixbuf[1];
+ 	__le32 buf[3];
+ 	u32 nodebuf[8];
+ 	struct ocontext *c;
+@@ -3213,17 +3192,12 @@ static int ocontext_write(struct policydb *p, struct policydb_compat_info *info,
+ 					return rc;
+ 				break;
+ 			case OCON_IBPKEY:
+-				/* subnet_prefix is in CPU order */
+-				prefixbuf[0] = cpu_to_be64(c->u.ibpkey.subnet_prefix);
++				*((__be64 *)nodebuf) = cpu_to_be64(c->u.ibpkey.subnet_prefix);
+ 
+-				rc = put_entry(prefixbuf, sizeof(u64), 1, fp);
+-				if (rc)
+-					return rc;
++				nodebuf[2] = cpu_to_le32(c->u.ibpkey.low_pkey);
++				nodebuf[3] = cpu_to_le32(c->u.ibpkey.high_pkey);
+ 
+-				buf[0] = cpu_to_le32(c->u.ibpkey.low_pkey);
+-				buf[1] = cpu_to_le32(c->u.ibpkey.high_pkey);
+-
+-				rc = put_entry(buf, sizeof(u32), 2, fp);
++				rc = put_entry(nodebuf, sizeof(u32), 4, fp);
+ 				if (rc)
+ 					return rc;
+ 				rc = context_write(p, &c->context[0], fp);
+diff --git a/security/selinux/ss/services.c b/security/selinux/ss/services.c
+index f3def298a90e..c7b40129e845 100644
+--- a/security/selinux/ss/services.c
++++ b/security/selinux/ss/services.c
+@@ -49,9 +49,9 @@
+ #include <linux/sched.h>
+ #include <linux/audit.h>
+ #include <linux/mutex.h>
+-#include <linux/selinux.h>
+ #include <linux/flex_array.h>
+ #include <linux/vmalloc.h>
++#include <linux/lsm_hooks.h>
+ #include <net/netlabel.h>
+ 
+ #include "flask.h"
+@@ -1365,7 +1365,6 @@ int security_sid_to_context_force(struct selinux_state *state, u32 sid,
+ static int string_to_context_struct(struct policydb *pol,
+ 				    struct sidtab *sidtabp,
+ 				    char *scontext,
+-				    u32 scontext_len,
+ 				    struct context *ctx,
+ 				    u32 def_sid)
+ {
+@@ -1426,15 +1425,12 @@ static int string_to_context_struct(struct policydb *pol,
+ 
+ 	ctx->type = typdatum->value;
+ 
+-	rc = mls_context_to_sid(pol, oldc, &p, ctx, sidtabp, def_sid);
++	rc = mls_context_to_sid(pol, oldc, p, ctx, sidtabp, def_sid);
+ 	if (rc)
+ 		goto out;
+ 
+-	rc = -EINVAL;
+-	if ((p - scontext) < scontext_len)
+-		goto out;
+-
+ 	/* Check the validity of the new context. */
++	rc = -EINVAL;
+ 	if (!policydb_context_isvalid(pol, ctx))
+ 		goto out;
+ 	rc = 0;
+@@ -1489,7 +1485,7 @@ static int security_context_to_sid_core(struct selinux_state *state,
+ 	policydb = &state->ss->policydb;
+ 	sidtab = &state->ss->sidtab;
+ 	rc = string_to_context_struct(policydb, sidtab, scontext2,
+-				      scontext_len, &context, def_sid);
++				      &context, def_sid);
+ 	if (rc == -EINVAL && force) {
+ 		context.str = str;
+ 		context.len = strlen(str) + 1;
+@@ -1958,7 +1954,7 @@ static int convert_context(u32 key,
+ 			goto out;
+ 
+ 		rc = string_to_context_struct(args->newp, NULL, s,
+-					      c->len, &ctx, SECSID_NULL);
++					      &ctx, SECSID_NULL);
+ 		kfree(s);
+ 		if (!rc) {
+ 			pr_info("SELinux:  Context %s became valid (mapped).\n",
+@@ -2765,7 +2761,7 @@ int security_fs_use(struct selinux_state *state, struct super_block *sb)
+ 	struct sidtab *sidtab;
+ 	int rc = 0;
+ 	struct ocontext *c;
+-	struct superblock_security_struct *sbsec = sb->s_security;
++	struct superblock_security_struct *sbsec = selinux_superblock(sb);
+ 	const char *fstype = sb->s_type->name;
+ 
+ 	read_lock(&state->ss->policy_rwlock);
+@@ -3408,14 +3404,15 @@ int selinux_audit_rule_known(struct audit_krule *rule)
+ 	return 0;
+ }
+ 
+-int selinux_audit_rule_match(u32 sid, u32 field, u32 op, void *vrule,
+-			     struct audit_context *actx)
++int selinux_audit_rule_match(struct lsm_export *l, u32 field, u32 op,
++			     void *vrule, struct audit_context *actx)
+ {
+ 	struct selinux_state *state = &selinux_state;
+ 	struct context *ctxt;
+ 	struct mls_level *level;
+ 	struct selinux_audit_rule *rule = vrule;
+ 	int match = 0;
++	u32 sid;
+ 
+ 	if (unlikely(!rule)) {
+ 		WARN_ONCE(1, "selinux_audit_rule_match: missing rule\n");
+@@ -3429,6 +3426,8 @@ int selinux_audit_rule_match(u32 sid, u32 field, u32 op, void *vrule,
+ 		goto out;
+ 	}
+ 
++	selinux_import_secid(l, &sid);
++
+ 	ctxt = sidtab_search(&state->ss->sidtab, sid);
+ 	if (unlikely(!ctxt)) {
+ 		WARN_ONCE(1, "selinux_audit_rule_match: unrecognized SID %d\n",
+@@ -3606,8 +3605,9 @@ int security_netlbl_secattr_to_sid(struct selinux_state *state,
+ 
+ 	if (secattr->flags & NETLBL_SECATTR_CACHE)
+ 		*sid = *(u32 *)secattr->cache->data;
+-	else if (secattr->flags & NETLBL_SECATTR_SECID)
+-		*sid = secattr->attr.secid;
++	else if (secattr->flags & NETLBL_SECATTR_SECID &&
++		 (secattr->attr.le.flags & LSM_EXPORT_SELINUX))
++		*sid = secattr->attr.le.selinux;
+ 	else if (secattr->flags & NETLBL_SECATTR_MLS_LVL) {
+ 		rc = -EIDRM;
+ 		ctx = sidtab_search(sidtab, SECINITSID_NETMSG);
+@@ -3680,7 +3680,9 @@ int security_netlbl_sid_to_secattr(struct selinux_state *state,
+ 	if (secattr->domain == NULL)
+ 		goto out;
+ 
+-	secattr->attr.secid = sid;
++	lsm_export_init(&secattr->attr.le);
++	secattr->attr.le.flags = LSM_EXPORT_SELINUX;
++	secattr->attr.le.selinux = sid;
+ 	secattr->flags |= NETLBL_SECATTR_DOMAIN_CPY | NETLBL_SECATTR_SECID;
+ 	mls_export_netlbl_lvl(policydb, ctx, secattr);
+ 	rc = mls_export_netlbl_cat(policydb, ctx, secattr);
+diff --git a/security/selinux/xfrm.c b/security/selinux/xfrm.c
+index 91dc3783ed94..8ffe7e1053c4 100644
+--- a/security/selinux/xfrm.c
++++ b/security/selinux/xfrm.c
+@@ -79,7 +79,7 @@ static int selinux_xfrm_alloc_user(struct xfrm_sec_ctx **ctxp,
+ 				   gfp_t gfp)
+ {
+ 	int rc;
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 	struct xfrm_sec_ctx *ctx = NULL;
+ 	u32 str_len;
+ 
+@@ -138,7 +138,7 @@ static void selinux_xfrm_free(struct xfrm_sec_ctx *ctx)
+  */
+ static int selinux_xfrm_delete(struct xfrm_sec_ctx *ctx)
+ {
+-	const struct task_security_struct *tsec = current_security();
++	const struct task_security_struct *tsec = selinux_cred(current_cred());
+ 
+ 	if (!ctx)
+ 		return 0;
+diff --git a/security/smack/smack.h b/security/smack/smack.h
+index f7db791fb566..147afb9233b4 100644
+--- a/security/smack/smack.h
++++ b/security/smack/smack.h
+@@ -24,6 +24,7 @@
+ #include <linux/list.h>
+ #include <linux/rculist.h>
+ #include <linux/lsm_audit.h>
++#include <linux/msg.h>
+ 
+ /*
+  * Use IPv6 port labeling if IPv6 is enabled and secmarks
+@@ -336,6 +337,7 @@ extern struct smack_known *smack_syslog_label;
+ extern struct smack_known *smack_unconfined;
+ #endif
+ extern int smack_ptrace_rule;
++extern struct lsm_blob_sizes smack_blob_sizes;
+ 
+ extern struct smack_known smack_known_floor;
+ extern struct smack_known smack_known_hat;
+@@ -356,12 +358,56 @@ extern struct list_head smack_onlycap_list;
+ #define SMACK_HASH_SLOTS 16
+ extern struct hlist_head smack_known_hash[SMACK_HASH_SLOTS];
+ 
++static inline struct task_smack *smack_cred(const struct cred *cred)
++{
++	return cred->security + smack_blob_sizes.lbs_cred;
++}
++
++static inline struct smack_known **smack_file(const struct file *file)
++{
++	return (struct smack_known **)(file->f_security +
++				       smack_blob_sizes.lbs_file);
++}
++
++static inline struct inode_smack *smack_inode(const struct inode *inode)
++{
++	return inode->i_security + smack_blob_sizes.lbs_inode;
++}
++
++static inline struct smack_known **smack_msg_msg(const struct msg_msg *msg)
++{
++	return msg->security + smack_blob_sizes.lbs_msg_msg;
++}
++
++static inline struct smack_known **smack_ipc(const struct kern_ipc_perm *ipc)
++{
++	return ipc->security + smack_blob_sizes.lbs_ipc;
++}
++
++static inline struct socket_smack *smack_sock(const struct sock *sock)
++{
++	return sock->sk_security + smack_blob_sizes.lbs_sock;
++}
++
++static inline struct superblock_smack *smack_superblock(
++					const struct super_block *superblock)
++{
++	return superblock->s_security + smack_blob_sizes.lbs_superblock;
++}
++
++#ifdef CONFIG_KEYS
++static inline struct smack_known **smack_key(const struct key *key)
++{
++	return key->security + smack_blob_sizes.lbs_key;
++}
++#endif /* CONFIG_KEYS */
++
+ /*
+  * Is the directory transmuting?
+  */
+ static inline int smk_inode_transmutable(const struct inode *isp)
+ {
+-	struct inode_smack *sip = isp->i_security;
++	struct inode_smack *sip = smack_inode(isp);
+ 	return (sip->smk_flags & SMK_INODE_TRANSMUTE) != 0;
+ }
+ 
+@@ -370,7 +416,7 @@ static inline int smk_inode_transmutable(const struct inode *isp)
+  */
+ static inline struct smack_known *smk_of_inode(const struct inode *isp)
+ {
+-	struct inode_smack *sip = isp->i_security;
++	struct inode_smack *sip = smack_inode(isp);
+ 	return sip->smk_inode;
+ }
+ 
+@@ -382,13 +428,19 @@ static inline struct smack_known *smk_of_task(const struct task_smack *tsp)
+ 	return tsp->smk_task;
+ }
+ 
+-static inline struct smack_known *smk_of_task_struct(const struct task_struct *t)
++static inline struct smack_known *smk_of_task_struct(
++						const struct task_struct *t)
+ {
+ 	struct smack_known *skp;
++	const struct cred *cred;
+ 
+ 	rcu_read_lock();
+-	skp = smk_of_task(__task_cred(t)->security);
++
++	cred = __task_cred(t);
++	skp = smk_of_task(smack_cred(cred));
++
+ 	rcu_read_unlock();
++
+ 	return skp;
+ }
+ 
+@@ -405,7 +457,7 @@ static inline struct smack_known *smk_of_forked(const struct task_smack *tsp)
+  */
+ static inline struct smack_known *smk_of_current(void)
+ {
+-	return smk_of_task(current_security());
++	return smk_of_task(smack_cred(current_cred()));
+ }
+ 
+ /*
+@@ -501,4 +553,19 @@ static inline void smk_ad_setfield_u_net_sk(struct smk_audit_info *a,
+ }
+ #endif
+ 
++#ifdef CONFIG_SECURITY_SMACK_NETFILTER
++extern bool smack_use_secmark;
++void smack_secmark_refcount_inc(void);
++
++static inline bool smk_use_secmark(void)
++{
++	return smack_use_secmark;
++}
++#else
++static inline bool smk_use_secmark(void)
++{
++	return false;
++}
++#endif
++
+ #endif  /* _SECURITY_SMACK_H */
+diff --git a/security/smack/smack_access.c b/security/smack/smack_access.c
+index a7855c61c05c..489d49a20b47 100644
+--- a/security/smack/smack_access.c
++++ b/security/smack/smack_access.c
+@@ -275,7 +275,7 @@ int smk_tskacc(struct task_smack *tsp, struct smack_known *obj_known,
+ int smk_curacc(struct smack_known *obj_known,
+ 	       u32 mode, struct smk_audit_info *a)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_tskacc(tsp, obj_known, mode, a);
+ }
+@@ -469,7 +469,7 @@ char *smk_parse_smack(const char *string, int len)
+ 	if (i == 0 || i >= SMK_LONGLABEL)
+ 		return ERR_PTR(-EINVAL);
+ 
+-	smack = kzalloc(i + 1, GFP_NOFS);
++	smack = kzalloc(i + 1, GFP_KERNEL);
+ 	if (smack == NULL)
+ 		return ERR_PTR(-ENOMEM);
+ 
+@@ -504,7 +504,7 @@ int smk_netlbl_mls(int level, char *catset, struct netlbl_lsm_secattr *sap,
+ 			if ((m & *cp) == 0)
+ 				continue;
+ 			rc = netlbl_catmap_setbit(&sap->attr.mls.cat,
+-						  cat, GFP_NOFS);
++						  cat, GFP_KERNEL);
+ 			if (rc < 0) {
+ 				netlbl_catmap_free(sap->attr.mls.cat);
+ 				return rc;
+@@ -540,7 +540,7 @@ struct smack_known *smk_import_entry(const char *string, int len)
+ 	if (skp != NULL)
+ 		goto freeout;
+ 
+-	skp = kzalloc(sizeof(*skp), GFP_NOFS);
++	skp = kzalloc(sizeof(*skp), GFP_KERNEL);
+ 	if (skp == NULL) {
+ 		skp = ERR_PTR(-ENOMEM);
+ 		goto freeout;
+@@ -635,12 +635,12 @@ DEFINE_MUTEX(smack_onlycap_lock);
+  */
+ bool smack_privileged_cred(int cap, const struct cred *cred)
+ {
+-	struct task_smack *tsp = cred->security;
++	struct task_smack *tsp = smack_cred(cred);
+ 	struct smack_known *skp = tsp->smk_task;
+ 	struct smack_known_list_elem *sklep;
+ 	int rc;
+ 
+-	rc = cap_capable(cred, &init_user_ns, cap, CAP_OPT_NONE);
++	rc = cap_capable(cred, &init_user_ns, cap, SECURITY_CAP_AUDIT);
+ 	if (rc)
+ 		return false;
+ 
+diff --git a/security/smack/smack_lsm.c b/security/smack/smack_lsm.c
+index 221de4c755c3..8da02f96783b 100644
+--- a/security/smack/smack_lsm.c
++++ b/security/smack/smack_lsm.c
+@@ -122,7 +122,7 @@ static int smk_bu_note(char *note, struct smack_known *sskp,
+ static int smk_bu_current(char *note, struct smack_known *oskp,
+ 			  int mode, int rc)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 	char acc[SMK_NUM_ACCESS_TYPE + 1];
+ 
+ 	if (rc <= 0)
+@@ -143,7 +143,7 @@ static int smk_bu_current(char *note, struct smack_known *oskp,
+ #ifdef CONFIG_SECURITY_SMACK_BRINGUP
+ static int smk_bu_task(struct task_struct *otp, int mode, int rc)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 	struct smack_known *smk_task = smk_of_task_struct(otp);
+ 	char acc[SMK_NUM_ACCESS_TYPE + 1];
+ 
+@@ -165,8 +165,8 @@ static int smk_bu_task(struct task_struct *otp, int mode, int rc)
+ #ifdef CONFIG_SECURITY_SMACK_BRINGUP
+ static int smk_bu_inode(struct inode *inode, int mode, int rc)
+ {
+-	struct task_smack *tsp = current_security();
+-	struct inode_smack *isp = inode->i_security;
++	struct task_smack *tsp = smack_cred(current_cred());
++	struct inode_smack *isp = smack_inode(inode);
+ 	char acc[SMK_NUM_ACCESS_TYPE + 1];
+ 
+ 	if (isp->smk_flags & SMK_INODE_IMPURE)
+@@ -195,10 +195,10 @@ static int smk_bu_inode(struct inode *inode, int mode, int rc)
+ #ifdef CONFIG_SECURITY_SMACK_BRINGUP
+ static int smk_bu_file(struct file *file, int mode, int rc)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 	struct smack_known *sskp = tsp->smk_task;
+ 	struct inode *inode = file_inode(file);
+-	struct inode_smack *isp = inode->i_security;
++	struct inode_smack *isp = smack_inode(inode);
+ 	char acc[SMK_NUM_ACCESS_TYPE + 1];
+ 
+ 	if (isp->smk_flags & SMK_INODE_IMPURE)
+@@ -225,10 +225,10 @@ static int smk_bu_file(struct file *file, int mode, int rc)
+ static int smk_bu_credfile(const struct cred *cred, struct file *file,
+ 				int mode, int rc)
+ {
+-	struct task_smack *tsp = cred->security;
++	struct task_smack *tsp = smack_cred(cred);
+ 	struct smack_known *sskp = tsp->smk_task;
+ 	struct inode *inode = file_inode(file);
+-	struct inode_smack *isp = inode->i_security;
++	struct inode_smack *isp = smack_inode(inode);
+ 	char acc[SMK_NUM_ACCESS_TYPE + 1];
+ 
+ 	if (isp->smk_flags & SMK_INODE_IMPURE)
+@@ -270,7 +270,7 @@ static struct smack_known *smk_fetch(const char *name, struct inode *ip,
+ 	if (!(ip->i_opflags & IOP_XATTR))
+ 		return ERR_PTR(-EOPNOTSUPP);
+ 
+-	buffer = kzalloc(SMK_LONGLABEL, GFP_NOFS);
++	buffer = kzalloc(SMK_LONGLABEL, GFP_KERNEL);
+ 	if (buffer == NULL)
+ 		return ERR_PTR(-ENOMEM);
+ 
+@@ -288,50 +288,35 @@ static struct smack_known *smk_fetch(const char *name, struct inode *ip,
+ }
+ 
+ /**
+- * new_inode_smack - allocate an inode security blob
++ * init_inode_smack - initialize an inode security blob
++ * @isp: the blob to initialize
+  * @skp: a pointer to the Smack label entry to use in the blob
+  *
+- * Returns the new blob or NULL if there's no memory available
+  */
+-static struct inode_smack *new_inode_smack(struct smack_known *skp)
++static void init_inode_smack(struct inode *inode, struct smack_known *skp)
+ {
+-	struct inode_smack *isp;
+-
+-	isp = kmem_cache_zalloc(smack_inode_cache, GFP_NOFS);
+-	if (isp == NULL)
+-		return NULL;
++	struct inode_smack *isp = smack_inode(inode);
+ 
+ 	isp->smk_inode = skp;
+ 	isp->smk_flags = 0;
+ 	mutex_init(&isp->smk_lock);
+-
+-	return isp;
+ }
+ 
+ /**
+- * new_task_smack - allocate a task security blob
++ * init_task_smack - initialize a task security blob
++ * @tsp: blob to initialize
+  * @task: a pointer to the Smack label for the running task
+  * @forked: a pointer to the Smack label for the forked task
+- * @gfp: type of the memory for the allocation
+  *
+- * Returns the new blob or NULL if there's no memory available
+  */
+-static struct task_smack *new_task_smack(struct smack_known *task,
+-					struct smack_known *forked, gfp_t gfp)
++static void init_task_smack(struct task_smack *tsp, struct smack_known *task,
++					struct smack_known *forked)
+ {
+-	struct task_smack *tsp;
+-
+-	tsp = kzalloc(sizeof(struct task_smack), gfp);
+-	if (tsp == NULL)
+-		return NULL;
+-
+ 	tsp->smk_task = task;
+ 	tsp->smk_forked = forked;
+ 	INIT_LIST_HEAD(&tsp->smk_rules);
+ 	INIT_LIST_HEAD(&tsp->smk_relabel);
+ 	mutex_init(&tsp->smk_rules_lock);
+-
+-	return tsp;
+ }
+ 
+ /**
+@@ -431,7 +416,7 @@ static int smk_ptrace_rule_check(struct task_struct *tracer,
+ 
+ 	rcu_read_lock();
+ 	tracercred = __task_cred(tracer);
+-	tsp = tracercred->security;
++	tsp = smack_cred(tracercred);
+ 	tracer_known = smk_of_task(tsp);
+ 
+ 	if ((mode & PTRACE_MODE_ATTACH) &&
+@@ -462,6 +447,23 @@ static int smk_ptrace_rule_check(struct task_struct *tracer,
+ 	return rc;
+ }
+ 
++/*
++ * Set the Smack secid in an lsm_export structure
++ */
++static inline void smack_export_secid(struct lsm_export *l, u32 secid)
++{
++	l->smack = secid;
++	l->flags |= LSM_EXPORT_SMACK;
++}
++
++static inline void smack_import_secid(struct lsm_export *l, u32 *secid)
++{
++	if (l->flags & LSM_EXPORT_SMACK)
++		*secid = l->smack;
++	else
++		*secid = 0;
++}
++
+ /*
+  * LSM hooks.
+  * We he, that is fun!
+@@ -498,7 +500,7 @@ static int smack_ptrace_traceme(struct task_struct *ptp)
+ 	int rc;
+ 	struct smack_known *skp;
+ 
+-	skp = smk_of_task(current_security());
++	skp = smk_of_task(smack_cred(current_cred()));
+ 
+ 	rc = smk_ptrace_rule_check(ptp, skp, PTRACE_MODE_ATTACH, __func__);
+ 	return rc;
+@@ -537,12 +539,7 @@ static int smack_syslog(int typefrom_file)
+  */
+ static int smack_sb_alloc_security(struct super_block *sb)
+ {
+-	struct superblock_smack *sbsp;
+-
+-	sbsp = kzalloc(sizeof(struct superblock_smack), GFP_KERNEL);
+-
+-	if (sbsp == NULL)
+-		return -ENOMEM;
++	struct superblock_smack *sbsp = smack_superblock(sb);
+ 
+ 	sbsp->smk_root = &smack_known_floor;
+ 	sbsp->smk_default = &smack_known_floor;
+@@ -551,22 +548,10 @@ static int smack_sb_alloc_security(struct super_block *sb)
+ 	/*
+ 	 * SMK_SB_INITIALIZED will be zero from kzalloc.
+ 	 */
+-	sb->s_security = sbsp;
+ 
+ 	return 0;
+ }
+ 
+-/**
+- * smack_sb_free_security - free a superblock blob
+- * @sb: the superblock getting the blob
+- *
+- */
+-static void smack_sb_free_security(struct super_block *sb)
+-{
+-	kfree(sb->s_security);
+-	sb->s_security = NULL;
+-}
+-
+ /**
+  * smack_sb_copy_data - copy mount options data for processing
+  * @orig: where to start
+@@ -624,8 +609,9 @@ static int smack_sb_copy_data(char *orig, char *smackopts)
+  * converts Smack specific mount options to generic security option format
+  */
+ static int smack_parse_opts_str(char *options,
+-		struct security_mnt_opts *opts)
++		struct security_mnt_opts *all_opts)
+ {
++	struct lsm_mnt_opts *opts = &all_opts->smack;
+ 	char *p;
+ 	char *fsdefault = NULL;
+ 	char *fsfloor = NULL;
+@@ -686,7 +672,6 @@ static int smack_parse_opts_str(char *options,
+ 				goto out_err;
+ 			break;
+ 		default:
+-			rc = -EINVAL;
+ 			pr_warn("Smack:  unknown mount option\n");
+ 			goto out_err;
+ 		}
+@@ -751,13 +736,14 @@ static int smack_parse_opts_str(char *options,
+  * labels.
+  */
+ static int smack_set_mnt_opts(struct super_block *sb,
+-		struct security_mnt_opts *opts,
++		struct security_mnt_opts *all_opts,
+ 		unsigned long kern_flags,
+ 		unsigned long *set_kern_flags)
+ {
++	struct lsm_mnt_opts *opts = &all_opts->smack;
+ 	struct dentry *root = sb->s_root;
+ 	struct inode *inode = d_backing_inode(root);
+-	struct superblock_smack *sp = sb->s_security;
++	struct superblock_smack *sp = smack_superblock(sb);
+ 	struct inode_smack *isp;
+ 	struct smack_known *skp;
+ 	int i;
+@@ -767,6 +753,13 @@ static int smack_set_mnt_opts(struct super_block *sb,
+ 	if (sp->smk_flags & SMK_SB_INITIALIZED)
+ 		return 0;
+ 
++	if (inode->i_security == NULL) {
++		int rc = lsm_inode_alloc(inode);
++
++		if (rc)
++			return rc;
++	}
++
+ 	if (!smack_privileged(CAP_MAC_ADMIN)) {
+ 		/*
+ 		 * Unprivileged mounts don't get to specify Smack values.
+@@ -835,17 +828,12 @@ static int smack_set_mnt_opts(struct super_block *sb,
+ 	/*
+ 	 * Initialize the root inode.
+ 	 */
+-	isp = inode->i_security;
+-	if (isp == NULL) {
+-		isp = new_inode_smack(sp->smk_root);
+-		if (isp == NULL)
+-			return -ENOMEM;
+-		inode->i_security = isp;
+-	} else
+-		isp->smk_inode = sp->smk_root;
++	init_inode_smack(inode, sp->smk_root);
+ 
+-	if (transmute)
++	if (transmute) {
++		isp = smack_inode(inode);
+ 		isp->smk_flags |= SMK_INODE_TRANSMUTE;
++	}
+ 
+ 	return 0;
+ }
+@@ -890,7 +878,7 @@ static int smack_sb_kern_mount(struct super_block *sb, int flags, void *data)
+  */
+ static int smack_sb_statfs(struct dentry *dentry)
+ {
+-	struct superblock_smack *sbp = dentry->d_sb->s_security;
++	struct superblock_smack *sbp = smack_superblock(dentry->d_sb);
+ 	int rc;
+ 	struct smk_audit_info ad;
+ 
+@@ -915,7 +903,7 @@ static int smack_sb_statfs(struct dentry *dentry)
+ static int smack_bprm_set_creds(struct linux_binprm *bprm)
+ {
+ 	struct inode *inode = file_inode(bprm->file);
+-	struct task_smack *bsp = bprm->cred->security;
++	struct task_smack *bsp = smack_cred(bprm->cred);
+ 	struct inode_smack *isp;
+ 	struct superblock_smack *sbsp;
+ 	int rc;
+@@ -923,11 +911,11 @@ static int smack_bprm_set_creds(struct linux_binprm *bprm)
+ 	if (bprm->called_set_creds)
+ 		return 0;
+ 
+-	isp = inode->i_security;
++	isp = smack_inode(inode);
+ 	if (isp->smk_task == NULL || isp->smk_task == bsp->smk_task)
+ 		return 0;
+ 
+-	sbsp = inode->i_sb->s_security;
++	sbsp = smack_superblock(inode->i_sb);
+ 	if ((sbsp->smk_flags & SMK_SB_UNTRUSTED) &&
+ 	    isp->smk_task != sbsp->smk_root)
+ 		return 0;
+@@ -947,8 +935,7 @@ static int smack_bprm_set_creds(struct linux_binprm *bprm)
+ 
+ 		if (rc != 0)
+ 			return rc;
+-	}
+-	if (bprm->unsafe & ~LSM_UNSAFE_PTRACE)
++	} else if (bprm->unsafe)
+ 		return -EPERM;
+ 
+ 	bsp->smk_task = isp->smk_task;
+@@ -975,48 +962,10 @@ static int smack_inode_alloc_security(struct inode *inode)
+ {
+ 	struct smack_known *skp = smk_of_current();
+ 
+-	inode->i_security = new_inode_smack(skp);
+-	if (inode->i_security == NULL)
+-		return -ENOMEM;
++	init_inode_smack(inode, skp);
+ 	return 0;
+ }
+ 
+-/**
+- * smack_inode_free_rcu - Free inode_smack blob from cache
+- * @head: the rcu_head for getting inode_smack pointer
+- *
+- *  Call back function called from call_rcu() to free
+- *  the i_security blob pointer in inode
+- */
+-static void smack_inode_free_rcu(struct rcu_head *head)
+-{
+-	struct inode_smack *issp;
+-
+-	issp = container_of(head, struct inode_smack, smk_rcu);
+-	kmem_cache_free(smack_inode_cache, issp);
+-}
+-
+-/**
+- * smack_inode_free_security - free an inode blob using call_rcu()
+- * @inode: the inode with a blob
+- *
+- * Clears the blob pointer in inode using RCU
+- */
+-static void smack_inode_free_security(struct inode *inode)
+-{
+-	struct inode_smack *issp = inode->i_security;
+-
+-	/*
+-	 * The inode may still be referenced in a path walk and
+-	 * a call to smack_inode_permission() can be made
+-	 * after smack_inode_free_security() is called.
+-	 * To avoid race condition free the i_security via RCU
+-	 * and leave the current inode->i_security pointer intact.
+-	 * The inode will be freed after the RCU grace period too.
+-	 */
+-	call_rcu(&issp->smk_rcu, smack_inode_free_rcu);
+-}
+-
+ /**
+  * smack_inode_init_security - copy out the smack from an inode
+  * @inode: the newly created inode
+@@ -1032,7 +981,7 @@ static int smack_inode_init_security(struct inode *inode, struct inode *dir,
+ 				     const struct qstr *qstr, const char **name,
+ 				     void **value, size_t *len)
+ {
+-	struct inode_smack *issp = inode->i_security;
++	struct inode_smack *issp = smack_inode(inode);
+ 	struct smack_known *skp = smk_of_current();
+ 	struct smack_known *isp = smk_of_inode(inode);
+ 	struct smack_known *dsp = smk_of_inode(dir);
+@@ -1217,7 +1166,7 @@ static int smack_inode_rename(struct inode *old_inode,
+  */
+ static int smack_inode_permission(struct inode *inode, int mask)
+ {
+-	struct superblock_smack *sbsp = inode->i_sb->s_security;
++	struct superblock_smack *sbsp = smack_superblock(inode->i_sb);
+ 	struct smk_audit_info ad;
+ 	int no_block = mask & MAY_NOT_BLOCK;
+ 	int rc;
+@@ -1330,7 +1279,7 @@ static int smack_inode_setxattr(struct dentry *dentry, const char *name,
+ 		    strncmp(value, TRANS_TRUE, TRANS_TRUE_SIZE) != 0)
+ 			rc = -EINVAL;
+ 	} else
+-		rc = cap_inode_setxattr(dentry, name, value, size, flags);
++		rc = -ENOSYS;
+ 
+ 	if (check_priv && !smack_privileged(CAP_MAC_ADMIN))
+ 		rc = -EPERM;
+@@ -1344,11 +1293,11 @@ static int smack_inode_setxattr(struct dentry *dentry, const char *name,
+ 			rc = -EINVAL;
+ 	}
+ 
+-	smk_ad_init(&ad, __func__, LSM_AUDIT_DATA_DENTRY);
+-	smk_ad_setfield_u_fs_path_dentry(&ad, dentry);
+-
+ 	if (rc == 0) {
+-		rc = smk_curacc(smk_of_inode(d_backing_inode(dentry)), MAY_WRITE, &ad);
++		smk_ad_init(&ad, __func__, LSM_AUDIT_DATA_DENTRY);
++		smk_ad_setfield_u_fs_path_dentry(&ad, dentry);
++		rc = smk_curacc(smk_of_inode(d_backing_inode(dentry)),
++				MAY_WRITE, &ad);
+ 		rc = smk_bu_inode(d_backing_inode(dentry), MAY_WRITE, rc);
+ 	}
+ 
+@@ -1370,7 +1319,7 @@ static void smack_inode_post_setxattr(struct dentry *dentry, const char *name,
+ 				      const void *value, size_t size, int flags)
+ {
+ 	struct smack_known *skp;
+-	struct inode_smack *isp = d_backing_inode(dentry)->i_security;
++	struct inode_smack *isp = smack_inode(d_backing_inode(dentry));
+ 
+ 	if (strcmp(name, XATTR_NAME_SMACKTRANSMUTE) == 0) {
+ 		isp->smk_flags |= SMK_INODE_TRANSMUTE;
+@@ -1451,7 +1400,7 @@ static int smack_inode_removexattr(struct dentry *dentry, const char *name)
+ 	if (rc != 0)
+ 		return rc;
+ 
+-	isp = d_backing_inode(dentry)->i_security;
++	isp = smack_inode(d_backing_inode(dentry));
+ 	/*
+ 	 * Don't do anything special for these.
+ 	 *	XATTR_NAME_SMACKIPIN
+@@ -1459,7 +1408,7 @@ static int smack_inode_removexattr(struct dentry *dentry, const char *name)
+ 	 */
+ 	if (strcmp(name, XATTR_NAME_SMACK) == 0) {
+ 		struct super_block *sbp = dentry->d_sb;
+-		struct superblock_smack *sbsp = sbp->s_security;
++		struct superblock_smack *sbsp = smack_superblock(sbp);
+ 
+ 		isp->smk_inode = sbsp->smk_default;
+ 	} else if (strcmp(name, XATTR_NAME_SMACKEXEC) == 0)
+@@ -1505,7 +1454,7 @@ static int smack_inode_getsecurity(struct inode *inode,
+ 		if (sock == NULL || sock->sk == NULL)
+ 			return -EOPNOTSUPP;
+ 
+-		ssp = sock->sk->sk_security;
++		ssp = smack_sock(sock->sk);
+ 
+ 		if (strcmp(name, XATTR_SMACK_IPIN) == 0)
+ 			isp = ssp->smk_in;
+@@ -1547,11 +1496,11 @@ static int smack_inode_listsecurity(struct inode *inode, char *buffer,
+  * @inode: inode to extract the info from
+  * @secid: where result will be saved
+  */
+-static void smack_inode_getsecid(struct inode *inode, u32 *secid)
++static void smack_inode_getsecid(struct inode *inode, struct lsm_export *l)
+ {
+ 	struct smack_known *skp = smk_of_inode(inode);
+ 
+-	*secid = skp->smk_secid;
++	smack_export_secid(l, skp->smk_secid);
+ }
+ 
+ /*
+@@ -1583,24 +1532,12 @@ static void smack_inode_getsecid(struct inode *inode, u32 *secid)
+  */
+ static int smack_file_alloc_security(struct file *file)
+ {
+-	struct smack_known *skp = smk_of_current();
++	struct smack_known **blob = smack_file(file);
+ 
+-	file->f_security = skp;
++	*blob = smk_of_current();
+ 	return 0;
+ }
+ 
+-/**
+- * smack_file_free_security - clear a file security blob
+- * @file: the object
+- *
+- * The security blob for a file is a pointer to the master
+- * label list, so no memory is freed.
+- */
+-static void smack_file_free_security(struct file *file)
+-{
+-	file->f_security = NULL;
+-}
+-
+ /**
+  * smack_file_ioctl - Smack check on ioctls
+  * @file: the object
+@@ -1738,16 +1675,16 @@ static int smack_mmap_file(struct file *file,
+ 	if (unlikely(IS_PRIVATE(file_inode(file))))
+ 		return 0;
+ 
+-	isp = file_inode(file)->i_security;
++	isp = smack_inode(file_inode(file));
+ 	if (isp->smk_mmap == NULL)
+ 		return 0;
+-	sbsp = file_inode(file)->i_sb->s_security;
++	sbsp = smack_superblock(file_inode(file)->i_sb);
+ 	if (sbsp->smk_flags & SMK_SB_UNTRUSTED &&
+ 	    isp->smk_mmap != sbsp->smk_root)
+ 		return -EACCES;
+ 	mkp = isp->smk_mmap;
+ 
+-	tsp = current_security();
++	tsp = smack_cred(current_cred());
+ 	skp = smk_of_current();
+ 	rc = 0;
+ 
+@@ -1825,7 +1762,9 @@ static int smack_mmap_file(struct file *file,
+  */
+ static void smack_file_set_fowner(struct file *file)
+ {
+-	file->f_security = smk_of_current();
++	struct smack_known **blob = smack_file(file);
++
++	*blob = smk_of_current();
+ }
+ 
+ /**
+@@ -1842,8 +1781,9 @@ static void smack_file_set_fowner(struct file *file)
+ static int smack_file_send_sigiotask(struct task_struct *tsk,
+ 				     struct fown_struct *fown, int signum)
+ {
++	struct smack_known **blob;
+ 	struct smack_known *skp;
+-	struct smack_known *tkp = smk_of_task(tsk->cred->security);
++	struct smack_known *tkp = smk_of_task(smack_cred(tsk->cred));
+ 	const struct cred *tcred;
+ 	struct file *file;
+ 	int rc;
+@@ -1855,7 +1795,8 @@ static int smack_file_send_sigiotask(struct task_struct *tsk,
+ 	file = container_of(fown, struct file, f_owner);
+ 
+ 	/* we don't log here as rc can be overriden */
+-	skp = file->f_security;
++	blob = smack_file(file);
++	skp = *blob;
+ 	rc = smk_access(skp, tkp, MAY_DELIVER, NULL);
+ 	rc = smk_bu_note("sigiotask", skp, tkp, MAY_DELIVER, rc);
+ 
+@@ -1895,8 +1836,8 @@ static int smack_file_receive(struct file *file)
+ 
+ 	if (inode->i_sb->s_magic == SOCKFS_MAGIC) {
+ 		sock = SOCKET_I(inode);
+-		ssp = sock->sk->sk_security;
+-		tsp = current_security();
++		ssp = smack_sock(sock->sk);
++		tsp = smack_cred(current_cred());
+ 		/*
+ 		 * If the receiving process can't write to the
+ 		 * passed socket or if the passed socket can't
+@@ -1938,7 +1879,7 @@ static int smack_file_receive(struct file *file)
+  */
+ static int smack_file_open(struct file *file)
+ {
+-	struct task_smack *tsp = file->f_cred->security;
++	struct task_smack *tsp = smack_cred(file->f_cred);
+ 	struct inode *inode = file_inode(file);
+ 	struct smk_audit_info ad;
+ 	int rc;
+@@ -1966,14 +1907,7 @@ static int smack_file_open(struct file *file)
+  */
+ static int smack_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+ {
+-	struct task_smack *tsp;
+-
+-	tsp = new_task_smack(NULL, NULL, gfp);
+-	if (tsp == NULL)
+-		return -ENOMEM;
+-
+-	cred->security = tsp;
+-
++	init_task_smack(smack_cred(cred), NULL, NULL);
+ 	return 0;
+ }
+ 
+@@ -1985,15 +1919,11 @@ static int smack_cred_alloc_blank(struct cred *cred, gfp_t gfp)
+  */
+ static void smack_cred_free(struct cred *cred)
+ {
+-	struct task_smack *tsp = cred->security;
++	struct task_smack *tsp = smack_cred(cred);
+ 	struct smack_rule *rp;
+ 	struct list_head *l;
+ 	struct list_head *n;
+ 
+-	if (tsp == NULL)
+-		return;
+-	cred->security = NULL;
+-
+ 	smk_destroy_label_list(&tsp->smk_relabel);
+ 
+ 	list_for_each_safe(l, n, &tsp->smk_rules) {
+@@ -2001,7 +1931,6 @@ static void smack_cred_free(struct cred *cred)
+ 		list_del(&rp->list);
+ 		kfree(rp);
+ 	}
+-	kfree(tsp);
+ }
+ 
+ /**
+@@ -2015,15 +1944,11 @@ static void smack_cred_free(struct cred *cred)
+ static int smack_cred_prepare(struct cred *new, const struct cred *old,
+ 			      gfp_t gfp)
+ {
+-	struct task_smack *old_tsp = old->security;
+-	struct task_smack *new_tsp;
++	struct task_smack *old_tsp = smack_cred(old);
++	struct task_smack *new_tsp = smack_cred(new);
+ 	int rc;
+ 
+-	new_tsp = new_task_smack(old_tsp->smk_task, old_tsp->smk_task, gfp);
+-	if (new_tsp == NULL)
+-		return -ENOMEM;
+-
+-	new->security = new_tsp;
++	init_task_smack(new_tsp, old_tsp->smk_task, old_tsp->smk_task);
+ 
+ 	rc = smk_copy_rules(&new_tsp->smk_rules, &old_tsp->smk_rules, gfp);
+ 	if (rc != 0)
+@@ -2031,10 +1956,7 @@ static int smack_cred_prepare(struct cred *new, const struct cred *old,
+ 
+ 	rc = smk_copy_relabel(&new_tsp->smk_relabel, &old_tsp->smk_relabel,
+ 				gfp);
+-	if (rc != 0)
+-		return rc;
+-
+-	return 0;
++	return rc;
+ }
+ 
+ /**
+@@ -2046,15 +1968,14 @@ static int smack_cred_prepare(struct cred *new, const struct cred *old,
+  */
+ static void smack_cred_transfer(struct cred *new, const struct cred *old)
+ {
+-	struct task_smack *old_tsp = old->security;
+-	struct task_smack *new_tsp = new->security;
++	struct task_smack *old_tsp = smack_cred(old);
++	struct task_smack *new_tsp = smack_cred(new);
+ 
+ 	new_tsp->smk_task = old_tsp->smk_task;
+ 	new_tsp->smk_forked = old_tsp->smk_task;
+ 	mutex_init(&new_tsp->smk_rules_lock);
+ 	INIT_LIST_HEAD(&new_tsp->smk_rules);
+ 
+-
+ 	/* cbs copy rule list */
+ }
+ 
+@@ -2065,13 +1986,13 @@ static void smack_cred_transfer(struct cred *new, const struct cred *old)
+  *
+  * Sets the secid to contain a u32 version of the smack label.
+  */
+-static void smack_cred_getsecid(const struct cred *c, u32 *secid)
++static void smack_cred_getsecid(const struct cred *cred, struct lsm_export *l)
+ {
+ 	struct smack_known *skp;
+ 
+ 	rcu_read_lock();
+-	skp = smk_of_task(c->security);
+-	*secid = skp->smk_secid;
++	skp = smk_of_task(smack_cred(cred));
++	smack_export_secid(l, skp->smk_secid);
+ 	rcu_read_unlock();
+ }
+ 
+@@ -2082,10 +2003,12 @@ static void smack_cred_getsecid(const struct cred *c, u32 *secid)
+  *
+  * Set the security data for a kernel service.
+  */
+-static int smack_kernel_act_as(struct cred *new, u32 secid)
++static int smack_kernel_act_as(struct cred *new, struct lsm_export *l)
+ {
+-	struct task_smack *new_tsp = new->security;
++	u32 secid;
++	struct task_smack *new_tsp = smack_cred(new);
+ 
++	smack_import_secid(l, &secid);
+ 	new_tsp->smk_task = smack_from_secid(secid);
+ 	return 0;
+ }
+@@ -2101,8 +2024,8 @@ static int smack_kernel_act_as(struct cred *new, u32 secid)
+ static int smack_kernel_create_files_as(struct cred *new,
+ 					struct inode *inode)
+ {
+-	struct inode_smack *isp = inode->i_security;
+-	struct task_smack *tsp = new->security;
++	struct inode_smack *isp = smack_inode(inode);
++	struct task_smack *tsp = smack_cred(new);
+ 
+ 	tsp->smk_forked = isp->smk_inode;
+ 	tsp->smk_task = tsp->smk_forked;
+@@ -2172,11 +2095,11 @@ static int smack_task_getsid(struct task_struct *p)
+  *
+  * Sets the secid to contain a u32 version of the smack label.
+  */
+-static void smack_task_getsecid(struct task_struct *p, u32 *secid)
++static void smack_task_getsecid(struct task_struct *p, struct lsm_export *l)
+ {
+ 	struct smack_known *skp = smk_of_task_struct(p);
+ 
+-	*secid = skp->smk_secid;
++	smack_export_secid(l, skp->smk_secid);
+ }
+ 
+ /**
+@@ -2286,7 +2209,7 @@ static int smack_task_kill(struct task_struct *p, struct siginfo *info,
+ 	 * specific behavior. This is not clean. For one thing
+ 	 * we can't take privilege into account.
+ 	 */
+-	skp = smk_of_task(cred->security);
++	skp = smk_of_task(smack_cred(cred));
+ 	rc = smk_access(skp, tkp, MAY_DELIVER, &ad);
+ 	rc = smk_bu_note("USB signal", skp, tkp, MAY_DELIVER, rc);
+ 	return rc;
+@@ -2301,7 +2224,7 @@ static int smack_task_kill(struct task_struct *p, struct siginfo *info,
+  */
+ static void smack_task_to_inode(struct task_struct *p, struct inode *inode)
+ {
+-	struct inode_smack *isp = inode->i_security;
++	struct inode_smack *isp = smack_inode(inode);
+ 	struct smack_known *skp = smk_of_task_struct(p);
+ 
+ 	isp->smk_inode = skp;
+@@ -2325,11 +2248,7 @@ static void smack_task_to_inode(struct task_struct *p, struct inode *inode)
+ static int smack_sk_alloc_security(struct sock *sk, int family, gfp_t gfp_flags)
+ {
+ 	struct smack_known *skp = smk_of_current();
+-	struct socket_smack *ssp;
+-
+-	ssp = kzalloc(sizeof(struct socket_smack), gfp_flags);
+-	if (ssp == NULL)
+-		return -ENOMEM;
++	struct socket_smack *ssp = smack_sock(sk);
+ 
+ 	/*
+ 	 * Sockets created by kernel threads receive web label.
+@@ -2343,11 +2262,10 @@ static int smack_sk_alloc_security(struct sock *sk, int family, gfp_t gfp_flags)
+ 	}
+ 	ssp->smk_packet = NULL;
+ 
+-	sk->sk_security = ssp;
+-
+ 	return 0;
+ }
+ 
++#ifdef SMACK_IPV6_PORT_LABELING
+ /**
+  * smack_sk_free_security - Free a socket blob
+  * @sk: the socket
+@@ -2356,7 +2274,6 @@ static int smack_sk_alloc_security(struct sock *sk, int family, gfp_t gfp_flags)
+  */
+ static void smack_sk_free_security(struct sock *sk)
+ {
+-#ifdef SMACK_IPV6_PORT_LABELING
+ 	struct smk_port_label *spp;
+ 
+ 	if (sk->sk_family == PF_INET6) {
+@@ -2369,9 +2286,8 @@ static void smack_sk_free_security(struct sock *sk)
+ 		}
+ 		rcu_read_unlock();
+ 	}
+-#endif
+-	kfree(sk->sk_security);
+ }
++#endif
+ 
+ /**
+ * smack_ipv4host_label - check host based restrictions
+@@ -2489,7 +2405,7 @@ static struct smack_known *smack_ipv6host_label(struct sockaddr_in6 *sip)
+ static int smack_netlabel(struct sock *sk, int labeled)
+ {
+ 	struct smack_known *skp;
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	int rc = 0;
+ 
+ 	/*
+@@ -2534,7 +2450,7 @@ static int smack_netlabel_send(struct sock *sk, struct sockaddr_in *sap)
+ 	int rc;
+ 	int sk_lbl;
+ 	struct smack_known *hkp;
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	struct smk_audit_info ad;
+ 
+ 	rcu_read_lock();
+@@ -2610,7 +2526,7 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
+ {
+ 	struct sock *sk = sock->sk;
+ 	struct sockaddr_in6 *addr6;
+-	struct socket_smack *ssp = sock->sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sock->sk);
+ 	struct smk_port_label *spp;
+ 	unsigned short port = 0;
+ 
+@@ -2697,7 +2613,7 @@ static int smk_ipv6_port_check(struct sock *sk, struct sockaddr_in6 *address,
+ 				int act)
+ {
+ 	struct smk_port_label *spp;
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	struct smack_known *skp = NULL;
+ 	unsigned short port;
+ 	struct smack_known *object;
+@@ -2764,7 +2680,7 @@ static int smack_inode_setsecurity(struct inode *inode, const char *name,
+ 				   const void *value, size_t size, int flags)
+ {
+ 	struct smack_known *skp;
+-	struct inode_smack *nsp = inode->i_security;
++	struct inode_smack *nsp = smack_inode(inode);
+ 	struct socket_smack *ssp;
+ 	struct socket *sock;
+ 	int rc = 0;
+@@ -2791,7 +2707,7 @@ static int smack_inode_setsecurity(struct inode *inode, const char *name,
+ 	if (sock == NULL || sock->sk == NULL)
+ 		return -EOPNOTSUPP;
+ 
+-	ssp = sock->sk->sk_security;
++	ssp = smack_sock(sock->sk);
+ 
+ 	if (strcmp(name, XATTR_SMACK_IPIN) == 0)
+ 		ssp->smk_in = skp;
+@@ -2839,7 +2755,7 @@ static int smack_socket_post_create(struct socket *sock, int family,
+ 	 * Sockets created by kernel threads receive web label.
+ 	 */
+ 	if (unlikely(current->flags & PF_KTHREAD)) {
+-		ssp = sock->sk->sk_security;
++		ssp = smack_sock(sock->sk);
+ 		ssp->smk_in = &smack_known_web;
+ 		ssp->smk_out = &smack_known_web;
+ 	}
+@@ -2864,8 +2780,8 @@ static int smack_socket_post_create(struct socket *sock, int family,
+ static int smack_socket_socketpair(struct socket *socka,
+ 		                   struct socket *sockb)
+ {
+-	struct socket_smack *asp = socka->sk->sk_security;
+-	struct socket_smack *bsp = sockb->sk->sk_security;
++	struct socket_smack *asp = smack_sock(socka->sk);
++	struct socket_smack *bsp = smack_sock(sockb->sk);
+ 
+ 	asp->smk_packet = bsp->smk_out;
+ 	bsp->smk_packet = asp->smk_out;
+@@ -2919,7 +2835,7 @@ static int smack_socket_connect(struct socket *sock, struct sockaddr *sap,
+ 		return 0;
+ 
+ #ifdef SMACK_IPV6_SECMARK_LABELING
+-	ssp = sock->sk->sk_security;
++	ssp = smack_sock(sock->sk);
+ #endif
+ 
+ 	switch (sock->sk->sk_family) {
+@@ -2973,23 +2889,12 @@ static int smack_flags_to_may(int flags)
+  */
+ static int smack_msg_msg_alloc_security(struct msg_msg *msg)
+ {
+-	struct smack_known *skp = smk_of_current();
++	struct smack_known **blob = smack_msg_msg(msg);
+ 
+-	msg->security = skp;
++	*blob = smk_of_current();
+ 	return 0;
+ }
+ 
+-/**
+- * smack_msg_msg_free_security - Clear the security blob for msg_msg
+- * @msg: the object
+- *
+- * Clears the blob pointer
+- */
+-static void smack_msg_msg_free_security(struct msg_msg *msg)
+-{
+-	msg->security = NULL;
+-}
+-
+ /**
+  * smack_of_ipc - the smack pointer for the ipc
+  * @isp: the object
+@@ -2998,7 +2903,9 @@ static void smack_msg_msg_free_security(struct msg_msg *msg)
+  */
+ static struct smack_known *smack_of_ipc(struct kern_ipc_perm *isp)
+ {
+-	return (struct smack_known *)isp->security;
++	struct smack_known **blob = smack_ipc(isp);
++
++	return *blob;
+ }
+ 
+ /**
+@@ -3009,23 +2916,12 @@ static struct smack_known *smack_of_ipc(struct kern_ipc_perm *isp)
+  */
+ static int smack_ipc_alloc_security(struct kern_ipc_perm *isp)
+ {
+-	struct smack_known *skp = smk_of_current();
++	struct smack_known **blob = smack_ipc(isp);
+ 
+-	isp->security = skp;
++	*blob = smk_of_current();
+ 	return 0;
+ }
+ 
+-/**
+- * smack_ipc_free_security - Clear the security blob for ipc
+- * @isp: the object
+- *
+- * Clears the blob pointer
+- */
+-static void smack_ipc_free_security(struct kern_ipc_perm *isp)
+-{
+-	isp->security = NULL;
+-}
+-
+ /**
+  * smk_curacc_shm : check if current has access on shm
+  * @isp : the object
+@@ -3323,7 +3219,8 @@ static int smack_msg_queue_msgrcv(struct kern_ipc_perm *isp, struct msg_msg *msg
+  */
+ static int smack_ipc_permission(struct kern_ipc_perm *ipp, short flag)
+ {
+-	struct smack_known *iskp = ipp->security;
++	struct smack_known **blob = smack_ipc(ipp);
++	struct smack_known *iskp = *blob;
+ 	int may = smack_flags_to_may(flag);
+ 	struct smk_audit_info ad;
+ 	int rc;
+@@ -3342,11 +3239,12 @@ static int smack_ipc_permission(struct kern_ipc_perm *ipp, short flag)
+  * @ipp: the object permissions
+  * @secid: where result will be saved
+  */
+-static void smack_ipc_getsecid(struct kern_ipc_perm *ipp, u32 *secid)
++static void smack_ipc_getsecid(struct kern_ipc_perm *ipp, struct lsm_export *l)
+ {
+-	struct smack_known *iskp = ipp->security;
++	struct smack_known **blob = smack_ipc(ipp);
++	struct smack_known *iskp = *blob;
+ 
+-	*secid = iskp->smk_secid;
++	smack_export_secid(l, iskp->smk_secid);
+ }
+ 
+ /**
+@@ -3372,7 +3270,7 @@ static void smack_d_instantiate(struct dentry *opt_dentry, struct inode *inode)
+ 	if (inode == NULL)
+ 		return;
+ 
+-	isp = inode->i_security;
++	isp = smack_inode(inode);
+ 
+ 	mutex_lock(&isp->smk_lock);
+ 	/*
+@@ -3383,7 +3281,7 @@ static void smack_d_instantiate(struct dentry *opt_dentry, struct inode *inode)
+ 		goto unlockandout;
+ 
+ 	sbp = inode->i_sb;
+-	sbsp = sbp->s_security;
++	sbsp = smack_superblock(sbp);
+ 	/*
+ 	 * We're going to use the superblock default label
+ 	 * if there's no label on the file.
+@@ -3475,7 +3373,7 @@ static void smack_d_instantiate(struct dentry *opt_dentry, struct inode *inode)
+ 		 */
+ 		final = &smack_known_star;
+ 		/*
+-		 * No break.
++		 * Fall through.
+ 		 *
+ 		 * If a smack value has been set we want to use it,
+ 		 * but since tmpfs isn't giving us the opportunity
+@@ -3613,7 +3511,7 @@ static int smack_getprocattr(struct task_struct *p, char *name, char **value)
+  */
+ static int smack_setprocattr(const char *name, void *value, size_t size)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 	struct cred *new;
+ 	struct smack_known *skp;
+ 	struct smack_known_list_elem *sklep;
+@@ -3654,7 +3552,7 @@ static int smack_setprocattr(const char *name, void *value, size_t size)
+ 	if (new == NULL)
+ 		return -ENOMEM;
+ 
+-	tsp = new->security;
++	tsp = smack_cred(new);
+ 	tsp->smk_task = skp;
+ 	/*
+ 	 * process can change its label only once
+@@ -3679,9 +3577,9 @@ static int smack_unix_stream_connect(struct sock *sock,
+ {
+ 	struct smack_known *skp;
+ 	struct smack_known *okp;
+-	struct socket_smack *ssp = sock->sk_security;
+-	struct socket_smack *osp = other->sk_security;
+-	struct socket_smack *nsp = newsk->sk_security;
++	struct socket_smack *ssp = smack_sock(sock);
++	struct socket_smack *osp = smack_sock(other);
++	struct socket_smack *nsp = smack_sock(newsk);
+ 	struct smk_audit_info ad;
+ 	int rc = 0;
+ #ifdef CONFIG_AUDIT
+@@ -3727,8 +3625,8 @@ static int smack_unix_stream_connect(struct sock *sock,
+  */
+ static int smack_unix_may_send(struct socket *sock, struct socket *other)
+ {
+-	struct socket_smack *ssp = sock->sk->sk_security;
+-	struct socket_smack *osp = other->sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sock->sk);
++	struct socket_smack *osp = smack_sock(other->sk);
+ 	struct smk_audit_info ad;
+ 	int rc;
+ 
+@@ -3765,7 +3663,7 @@ static int smack_socket_sendmsg(struct socket *sock, struct msghdr *msg,
+ 	struct sockaddr_in6 *sap = (struct sockaddr_in6 *) msg->msg_name;
+ #endif
+ #ifdef SMACK_IPV6_SECMARK_LABELING
+-	struct socket_smack *ssp = sock->sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sock->sk);
+ 	struct smack_known *rsp;
+ #endif
+ 	int rc = 0;
+@@ -3857,11 +3755,12 @@ static struct smack_known *smack_from_secattr(struct netlbl_lsm_secattr *sap,
+ 			return &smack_known_web;
+ 		return &smack_known_star;
+ 	}
+-	if ((sap->flags & NETLBL_SECATTR_SECID) != 0)
++	if ((sap->flags & NETLBL_SECATTR_SECID) != 0 &&
++	    (sap->attr.le.flags & LSM_EXPORT_SMACK))
+ 		/*
+ 		 * Looks like a fallback, which gives us a secid.
+ 		 */
+-		return smack_from_secid(sap->attr.secid);
++		return smack_from_secid(sap->attr.le.smack);
+ 	/*
+ 	 * Without guidance regarding the smack value
+ 	 * for the packet fall back on the network
+@@ -3920,6 +3819,20 @@ static int smk_skb_to_addr_ipv6(struct sk_buff *skb, struct sockaddr_in6 *sip)
+ }
+ #endif /* CONFIG_IPV6 */
+ 
++/**
++ * smack_from_skb - Smack data from the secmark in an skb
++ * @skb: packet
++ *
++ * Returns smack_known of the secmark or NULL if that won't work.
++ */
++static struct smack_known *smack_from_skb(struct sk_buff *skb)
++{
++	if (skb == NULL || skb->secmark == 0 || !smk_use_secmark())
++		return NULL;
++
++	return smack_from_secid(skb->secmark);
++}
++
+ /**
+  * smack_socket_sock_rcv_skb - Smack packet delivery access check
+  * @sk: socket
+@@ -3930,7 +3843,7 @@ static int smk_skb_to_addr_ipv6(struct sk_buff *skb, struct sockaddr_in6 *sip)
+ static int smack_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ {
+ 	struct netlbl_lsm_secattr secattr;
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	struct smack_known *skp = NULL;
+ 	int rc = 0;
+ 	struct smk_audit_info ad;
+@@ -3948,17 +3861,14 @@ static int smack_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ 
+ 	switch (family) {
+ 	case PF_INET:
+-#ifdef CONFIG_SECURITY_SMACK_NETFILTER
+ 		/*
+ 		 * If there is a secmark use it rather than the CIPSO label.
+ 		 * If there is no secmark fall back to CIPSO.
+ 		 * The secmark is assumed to reflect policy better.
+ 		 */
+-		if (skb && skb->secmark != 0) {
+-			skp = smack_from_secid(skb->secmark);
++		skp = smack_from_skb(skb);
++		if (skp)
+ 			goto access_check;
+-		}
+-#endif /* CONFIG_SECURITY_SMACK_NETFILTER */
+ 		/*
+ 		 * Translate what netlabel gave us.
+ 		 */
+@@ -3972,9 +3882,8 @@ static int smack_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ 
+ 		netlbl_secattr_destroy(&secattr);
+ 
+-#ifdef CONFIG_SECURITY_SMACK_NETFILTER
+ access_check:
+-#endif
++
+ #ifdef CONFIG_AUDIT
+ 		smk_ad_init_net(&ad, __func__, LSM_AUDIT_DATA_NET, &net);
+ 		ad.a.u.net->family = family;
+@@ -4000,14 +3909,11 @@ static int smack_socket_sock_rcv_skb(struct sock *sk, struct sk_buff *skb)
+ 		    proto != IPPROTO_TCP && proto != IPPROTO_DCCP)
+ 			break;
+ #ifdef SMACK_IPV6_SECMARK_LABELING
+-		if (skb && skb->secmark != 0)
+-			skp = smack_from_secid(skb->secmark);
+-		else
++		skp = smack_from_skb(skb);
++		if (skp == NULL)
+ 			skp = smack_ipv6host_label(&sadd);
+ 		if (skp == NULL)
+ 			skp = smack_net_ambient;
+-		if (skb == NULL)
+-			break;
+ #ifdef CONFIG_AUDIT
+ 		smk_ad_init_net(&ad, __func__, LSM_AUDIT_DATA_NET, &net);
+ 		ad.a.u.net->family = family;
+@@ -4049,7 +3955,7 @@ static int smack_socket_getpeersec_stream(struct socket *sock,
+ 	int slen = 1;
+ 	int rc = 0;
+ 
+-	ssp = sock->sk->sk_security;
++	ssp = smack_sock(sock->sk);
+ 	if (ssp->smk_packet != NULL) {
+ 		rcp = ssp->smk_packet->smk_known;
+ 		slen = strlen(rcp) + 1;
+@@ -4076,7 +3982,8 @@ static int smack_socket_getpeersec_stream(struct socket *sock,
+  * Sets the netlabel socket state on sk from parent
+  */
+ static int smack_socket_getpeersec_dgram(struct socket *sock,
+-					 struct sk_buff *skb, u32 *secid)
++					 struct sk_buff *skb,
++					 struct lsm_export *l)
+ 
+ {
+ 	struct netlbl_lsm_secattr secattr;
+@@ -4099,20 +4006,20 @@ static int smack_socket_getpeersec_dgram(struct socket *sock,
+ 
+ 	switch (family) {
+ 	case PF_UNIX:
+-		ssp = sock->sk->sk_security;
++		ssp = smack_sock(sock->sk);
+ 		s = ssp->smk_out->smk_secid;
+ 		break;
+ 	case PF_INET:
+-#ifdef CONFIG_SECURITY_SMACK_NETFILTER
+-		s = skb->secmark;
+-		if (s != 0)
++		skp = smack_from_skb(skb);
++		if (skp) {
++			s = skp->smk_secid;
+ 			break;
+-#endif
++		}
+ 		/*
+ 		 * Translate what netlabel gave us.
+ 		 */
+ 		if (sock != NULL && sock->sk != NULL)
+-			ssp = sock->sk->sk_security;
++			ssp = smack_sock(sock->sk);
+ 		netlbl_secattr_init(&secattr);
+ 		rc = netlbl_skbuff_getattr(skb, family, &secattr);
+ 		if (rc == 0) {
+@@ -4123,11 +4030,13 @@ static int smack_socket_getpeersec_dgram(struct socket *sock,
+ 		break;
+ 	case PF_INET6:
+ #ifdef SMACK_IPV6_SECMARK_LABELING
+-		s = skb->secmark;
++		skp = smack_from_skb(skb);
++		if (skp)
++			s = skp->smk_secid;
+ #endif
+ 		break;
+ 	}
+-	*secid = s;
++	smack_export_secid(l, s);
+ 	if (s == 0)
+ 		return -EINVAL;
+ 	return 0;
+@@ -4150,7 +4059,7 @@ static void smack_sock_graft(struct sock *sk, struct socket *parent)
+ 	    (sk->sk_family != PF_INET && sk->sk_family != PF_INET6))
+ 		return;
+ 
+-	ssp = sk->sk_security;
++	ssp = smack_sock(sk);
+ 	ssp->smk_in = skp;
+ 	ssp->smk_out = skp;
+ 	/* cssp->smk_packet is already set in smack_inet_csk_clone() */
+@@ -4170,7 +4079,7 @@ static int smack_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ {
+ 	u16 family = sk->sk_family;
+ 	struct smack_known *skp;
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	struct netlbl_lsm_secattr secattr;
+ 	struct sockaddr_in addr;
+ 	struct iphdr *hdr;
+@@ -4195,17 +4104,14 @@ static int smack_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ 	}
+ #endif /* CONFIG_IPV6 */
+ 
+-#ifdef CONFIG_SECURITY_SMACK_NETFILTER
+ 	/*
+ 	 * If there is a secmark use it rather than the CIPSO label.
+ 	 * If there is no secmark fall back to CIPSO.
+ 	 * The secmark is assumed to reflect policy better.
+ 	 */
+-	if (skb && skb->secmark != 0) {
+-		skp = smack_from_secid(skb->secmark);
++	skp = smack_from_skb(skb);
++	if (skp)
+ 		goto access_check;
+-	}
+-#endif /* CONFIG_SECURITY_SMACK_NETFILTER */
+ 
+ 	netlbl_secattr_init(&secattr);
+ 	rc = netlbl_skbuff_getattr(skb, family, &secattr);
+@@ -4215,9 +4121,7 @@ static int smack_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ 		skp = &smack_known_huh;
+ 	netlbl_secattr_destroy(&secattr);
+ 
+-#ifdef CONFIG_SECURITY_SMACK_NETFILTER
+ access_check:
+-#endif
+ 
+ #ifdef CONFIG_AUDIT
+ 	smk_ad_init_net(&ad, __func__, LSM_AUDIT_DATA_NET, &net);
+@@ -4269,7 +4173,7 @@ static int smack_inet_conn_request(struct sock *sk, struct sk_buff *skb,
+ static void smack_inet_csk_clone(struct sock *sk,
+ 				 const struct request_sock *req)
+ {
+-	struct socket_smack *ssp = sk->sk_security;
++	struct socket_smack *ssp = smack_sock(sk);
+ 	struct smack_known *skp;
+ 
+ 	if (req->peer_secid != 0) {
+@@ -4301,23 +4205,13 @@ static void smack_inet_csk_clone(struct sock *sk,
+ static int smack_key_alloc(struct key *key, const struct cred *cred,
+ 			   unsigned long flags)
+ {
+-	struct smack_known *skp = smk_of_task(cred->security);
++	struct smack_known **blob = smack_key(key);
++	struct smack_known *skp = smk_of_task(smack_cred(cred));
+ 
+-	key->security = skp;
++	*blob = skp;
+ 	return 0;
+ }
+ 
+-/**
+- * smack_key_free - Clear the key security blob
+- * @key: the object
+- *
+- * Clear the blob pointer
+- */
+-static void smack_key_free(struct key *key)
+-{
+-	key->security = NULL;
+-}
+-
+ /**
+  * smack_key_permission - Smack access on a key
+  * @key_ref: gets to the object
+@@ -4330,18 +4224,14 @@ static void smack_key_free(struct key *key)
+ static int smack_key_permission(key_ref_t key_ref,
+ 				const struct cred *cred, unsigned perm)
+ {
++	struct smack_known **blob;
++	struct smack_known *skp;
+ 	struct key *keyp;
+ 	struct smk_audit_info ad;
+-	struct smack_known *tkp = smk_of_task(cred->security);
++	struct smack_known *tkp = smk_of_task(smack_cred(cred));
+ 	int request = 0;
+ 	int rc;
+ 
+-	/*
+-	 * Validate requested permissions
+-	 */
+-	if (perm & ~KEY_NEED_ALL)
+-		return -EINVAL;
+-
+ 	keyp = key_ref_to_ptr(key_ref);
+ 	if (keyp == NULL)
+ 		return -EINVAL;
+@@ -4349,7 +4239,9 @@ static int smack_key_permission(key_ref_t key_ref,
+ 	 * If the key hasn't been initialized give it access so that
+ 	 * it may do so.
+ 	 */
+-	if (keyp->security == NULL)
++	blob = smack_key(keyp);
++	skp = *blob;
++	if (skp == NULL)
+ 		return 0;
+ 	/*
+ 	 * This should not occur
+@@ -4365,12 +4257,12 @@ static int smack_key_permission(key_ref_t key_ref,
+ 	ad.a.u.key_struct.key = keyp->serial;
+ 	ad.a.u.key_struct.key_desc = keyp->description;
+ #endif
+-	if (perm & (KEY_NEED_READ | KEY_NEED_SEARCH | KEY_NEED_VIEW))
+-		request |= MAY_READ;
++	if (perm & KEY_NEED_READ)
++		request = MAY_READ;
+ 	if (perm & (KEY_NEED_WRITE | KEY_NEED_LINK | KEY_NEED_SETATTR))
+-		request |= MAY_WRITE;
+-	rc = smk_access(tkp, keyp->security, request, &ad);
+-	rc = smk_bu_note("key access", tkp, keyp->security, request, rc);
++		request = MAY_WRITE;
++	rc = smk_access(tkp, skp, request, &ad);
++	rc = smk_bu_note("key access", tkp, skp, request, rc);
+ 	return rc;
+ }
+ 
+@@ -4385,11 +4277,12 @@ static int smack_key_permission(key_ref_t key_ref,
+  */
+ static int smack_key_getsecurity(struct key *key, char **_buffer)
+ {
+-	struct smack_known *skp = key->security;
++	struct smack_known **blob = smack_key(key);
++	struct smack_known *skp = *blob;
+ 	size_t length;
+ 	char *copy;
+ 
+-	if (key->security == NULL) {
++	if (skp == NULL) {
+ 		*_buffer = NULL;
+ 		return 0;
+ 	}
+@@ -4476,7 +4369,7 @@ static int smack_audit_rule_known(struct audit_krule *krule)
+ 
+ /**
+  * smack_audit_rule_match - Audit given object ?
+- * @secid: security id for identifying the object to test
++ * @l: security id for identifying the object to test
+  * @field: audit rule flags given from user-space
+  * @op: required testing operator
+  * @vrule: smack internal rule presentation
+@@ -4485,11 +4378,12 @@ static int smack_audit_rule_known(struct audit_krule *krule)
+  * The core Audit hook. It's used to take the decision of
+  * whether to audit or not to audit a given object.
+  */
+-static int smack_audit_rule_match(u32 secid, u32 field, u32 op, void *vrule,
+-				  struct audit_context *actx)
++static int smack_audit_rule_match(struct lsm_export *l, u32 field, u32 op,
++				  void *vrule, struct audit_context *actx)
+ {
+ 	struct smack_known *skp;
+ 	char *rule = vrule;
++	u32 secid;
+ 
+ 	if (unlikely(!rule)) {
+ 		WARN_ONCE(1, "Smack: missing rule\n");
+@@ -4499,6 +4393,7 @@ static int smack_audit_rule_match(u32 secid, u32 field, u32 op, void *vrule,
+ 	if (field != AUDIT_SUBJ_USER && field != AUDIT_OBJ_USER)
+ 		return 0;
+ 
++	smack_import_secid(l, &secid);
+ 	skp = smack_from_secid(secid);
+ 
+ 	/*
+@@ -4530,6 +4425,12 @@ static int smack_ismaclabel(const char *name)
+ 	return (strcmp(name, XATTR_SMACK_SUFFIX) == 0);
+ }
+ 
++/*
++ * The smack_release_secctx hook does nothing
++ */
++static void smack_release_secctx(struct lsm_context *cp)
++{
++}
+ 
+ /**
+  * smack_secid_to_secctx - return the smack label for a secid
+@@ -4539,13 +4440,17 @@ static int smack_ismaclabel(const char *name)
+  *
+  * Exists for networking code.
+  */
+-static int smack_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
++static int smack_secid_to_secctx(struct lsm_export *l, struct lsm_context *cp)
+ {
+-	struct smack_known *skp = smack_from_secid(secid);
++	struct smack_known *skp;
++	u32 secid;
+ 
+-	if (secdata)
+-		*secdata = skp->smk_known;
+-	*seclen = strlen(skp->smk_known);
++	smack_import_secid(l, &secid);
++	skp = smack_from_secid(secid);
++
++	cp->context = (l->flags & LSM_EXPORT_LENGTH) ? NULL : skp->smk_known;
++	cp->len = strlen(skp->smk_known);
++	cp->release = smack_release_secctx;
+ 	return 0;
+ }
+ 
+@@ -4557,39 +4462,37 @@ static int smack_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
+  *
+  * Exists for audit and networking code.
+  */
+-static int smack_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
++static int smack_secctx_to_secid(const struct lsm_context *cp,
++				 struct lsm_export *l)
+ {
+-	struct smack_known *skp = smk_find_entry(secdata);
++	struct smack_known *skp = smk_find_entry(cp->context);
+ 
+ 	if (skp)
+-		*secid = skp->smk_secid;
++		smack_export_secid(l, skp->smk_secid);
+ 	else
+-		*secid = 0;
++		smack_export_secid(l, 0);
+ 	return 0;
+ }
+ 
+-/*
+- * There used to be a smack_release_secctx hook
+- * that did nothing back when hooks were in a vector.
+- * Now that there's a list such a hook adds cost.
+- */
+-
+-static int smack_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen)
++static int smack_inode_notifysecctx(struct inode *inode, struct lsm_context *cp)
+ {
+-	return smack_inode_setsecurity(inode, XATTR_SMACK_SUFFIX, ctx, ctxlen, 0);
++	return smack_inode_setsecurity(inode, XATTR_SMACK_SUFFIX, cp->context,
++				       cp->len, 0);
+ }
+ 
+-static int smack_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen)
++static int smack_inode_setsecctx(struct dentry *dentry, struct lsm_context *cp)
+ {
+-	return __vfs_setxattr_noperm(dentry, XATTR_NAME_SMACK, ctx, ctxlen, 0);
++	return __vfs_setxattr_noperm(dentry, XATTR_NAME_SMACK, cp->context,
++				     cp->len, 0);
+ }
+ 
+-static int smack_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen)
++static int smack_inode_getsecctx(struct inode *inode, struct lsm_context *cp)
+ {
+ 	struct smack_known *skp = smk_of_inode(inode);
+ 
+-	*ctx = skp->smk_known;
+-	*ctxlen = strlen(skp->smk_known);
++	cp->context = skp->smk_known;
++	cp->len = strlen(skp->smk_known);
++	cp->release = smack_release_secctx;
+ 	return 0;
+ }
+ 
+@@ -4607,12 +4510,12 @@ static int smack_inode_copy_up(struct dentry *dentry, struct cred **new)
+ 			return -ENOMEM;
+ 	}
+ 
+-	tsp = new_creds->security;
++	tsp = smack_cred(new_creds);
+ 
+ 	/*
+ 	 * Get label from overlay inode and set it in create_sid
+ 	 */
+-	isp = d_inode(dentry->d_parent)->i_security;
++	isp = smack_inode(d_inode(dentry->d_parent));
+ 	skp = isp->smk_inode;
+ 	tsp->smk_task = skp;
+ 	*new = new_creds;
+@@ -4635,8 +4538,8 @@ static int smack_dentry_create_files_as(struct dentry *dentry, int mode,
+ 					const struct cred *old,
+ 					struct cred *new)
+ {
+-	struct task_smack *otsp = old->security;
+-	struct task_smack *ntsp = new->security;
++	struct task_smack *otsp = smack_cred(old);
++	struct task_smack *ntsp = smack_cred(new);
+ 	struct inode_smack *isp;
+ 	int may;
+ 
+@@ -4649,7 +4552,7 @@ static int smack_dentry_create_files_as(struct dentry *dentry, int mode,
+ 	/*
+ 	 * the attribute of the containing directory
+ 	 */
+-	isp = d_inode(dentry->d_parent)->i_security;
++	isp = smack_inode(d_inode(dentry->d_parent));
+ 
+ 	if (isp->smk_flags & SMK_INODE_TRANSMUTE) {
+ 		rcu_read_lock();
+@@ -4669,13 +4572,25 @@ static int smack_dentry_create_files_as(struct dentry *dentry, int mode,
+ 	return 0;
+ }
+ 
++struct lsm_blob_sizes smack_blob_sizes __lsm_ro_after_init = {
++	.lbs_cred = sizeof(struct task_smack),
++	.lbs_file = sizeof(struct smack_known *),
++	.lbs_inode = sizeof(struct inode_smack),
++	.lbs_ipc = sizeof(struct smack_known *),
++#ifdef CONFIG_KEYS
++	.lbs_key = sizeof(struct smack_known *),
++#endif /* CONFIG_KEYS */
++	.lbs_msg_msg = sizeof(struct smack_known *),
++	.lbs_sock = sizeof(struct socket_smack),
++	.lbs_superblock = sizeof(struct superblock_smack),
++};
++
+ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(ptrace_access_check, smack_ptrace_access_check),
+ 	LSM_HOOK_INIT(ptrace_traceme, smack_ptrace_traceme),
+ 	LSM_HOOK_INIT(syslog, smack_syslog),
+ 
+ 	LSM_HOOK_INIT(sb_alloc_security, smack_sb_alloc_security),
+-	LSM_HOOK_INIT(sb_free_security, smack_sb_free_security),
+ 	LSM_HOOK_INIT(sb_copy_data, smack_sb_copy_data),
+ 	LSM_HOOK_INIT(sb_kern_mount, smack_sb_kern_mount),
+ 	LSM_HOOK_INIT(sb_statfs, smack_sb_statfs),
+@@ -4685,7 +4600,6 @@ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(bprm_set_creds, smack_bprm_set_creds),
+ 
+ 	LSM_HOOK_INIT(inode_alloc_security, smack_inode_alloc_security),
+-	LSM_HOOK_INIT(inode_free_security, smack_inode_free_security),
+ 	LSM_HOOK_INIT(inode_init_security, smack_inode_init_security),
+ 	LSM_HOOK_INIT(inode_link, smack_inode_link),
+ 	LSM_HOOK_INIT(inode_unlink, smack_inode_unlink),
+@@ -4704,7 +4618,6 @@ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(inode_getsecid, smack_inode_getsecid),
+ 
+ 	LSM_HOOK_INIT(file_alloc_security, smack_file_alloc_security),
+-	LSM_HOOK_INIT(file_free_security, smack_file_free_security),
+ 	LSM_HOOK_INIT(file_ioctl, smack_file_ioctl),
+ 	LSM_HOOK_INIT(file_lock, smack_file_lock),
+ 	LSM_HOOK_INIT(file_fcntl, smack_file_fcntl),
+@@ -4740,23 +4653,19 @@ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(ipc_getsecid, smack_ipc_getsecid),
+ 
+ 	LSM_HOOK_INIT(msg_msg_alloc_security, smack_msg_msg_alloc_security),
+-	LSM_HOOK_INIT(msg_msg_free_security, smack_msg_msg_free_security),
+ 
+ 	LSM_HOOK_INIT(msg_queue_alloc_security, smack_ipc_alloc_security),
+-	LSM_HOOK_INIT(msg_queue_free_security, smack_ipc_free_security),
+ 	LSM_HOOK_INIT(msg_queue_associate, smack_msg_queue_associate),
+ 	LSM_HOOK_INIT(msg_queue_msgctl, smack_msg_queue_msgctl),
+ 	LSM_HOOK_INIT(msg_queue_msgsnd, smack_msg_queue_msgsnd),
+ 	LSM_HOOK_INIT(msg_queue_msgrcv, smack_msg_queue_msgrcv),
+ 
+ 	LSM_HOOK_INIT(shm_alloc_security, smack_ipc_alloc_security),
+-	LSM_HOOK_INIT(shm_free_security, smack_ipc_free_security),
+ 	LSM_HOOK_INIT(shm_associate, smack_shm_associate),
+ 	LSM_HOOK_INIT(shm_shmctl, smack_shm_shmctl),
+ 	LSM_HOOK_INIT(shm_shmat, smack_shm_shmat),
+ 
+ 	LSM_HOOK_INIT(sem_alloc_security, smack_ipc_alloc_security),
+-	LSM_HOOK_INIT(sem_free_security, smack_ipc_free_security),
+ 	LSM_HOOK_INIT(sem_associate, smack_sem_associate),
+ 	LSM_HOOK_INIT(sem_semctl, smack_sem_semctl),
+ 	LSM_HOOK_INIT(sem_semop, smack_sem_semop),
+@@ -4780,7 +4689,12 @@ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+ 	LSM_HOOK_INIT(socket_getpeersec_stream, smack_socket_getpeersec_stream),
+ 	LSM_HOOK_INIT(socket_getpeersec_dgram, smack_socket_getpeersec_dgram),
+ 	LSM_HOOK_INIT(sk_alloc_security, smack_sk_alloc_security),
++#ifdef SMACK_IPV6_PORT_LABELING
+ 	LSM_HOOK_INIT(sk_free_security, smack_sk_free_security),
++#endif
++#ifdef CONFIG_SECURITY_SMACK_NETFILTER
++	LSM_HOOK_INIT(secmark_refcount_inc, smack_secmark_refcount_inc),
++#endif
+ 	LSM_HOOK_INIT(sock_graft, smack_sock_graft),
+ 	LSM_HOOK_INIT(inet_conn_request, smack_inet_conn_request),
+ 	LSM_HOOK_INIT(inet_csk_clone, smack_inet_csk_clone),
+@@ -4788,7 +4702,6 @@ static struct security_hook_list smack_hooks[] __lsm_ro_after_init = {
+  /* key management security hooks */
+ #ifdef CONFIG_KEYS
+ 	LSM_HOOK_INIT(key_alloc, smack_key_alloc),
+-	LSM_HOOK_INIT(key_free, smack_key_free),
+ 	LSM_HOOK_INIT(key_permission, smack_key_permission),
+ 	LSM_HOOK_INIT(key_getsecurity, smack_key_getsecurity),
+ #endif /* CONFIG_KEYS */
+@@ -4847,23 +4760,25 @@ static __init void init_smack_known_list(void)
+  */
+ static __init int smack_init(void)
+ {
+-	struct cred *cred;
++	struct cred *cred = (struct cred *) current->cred;
+ 	struct task_smack *tsp;
+ 
+-	if (!security_module_enable("smack"))
+-		return 0;
+-
+ 	smack_inode_cache = KMEM_CACHE(inode_smack, 0);
+ 	if (!smack_inode_cache)
+ 		return -ENOMEM;
+ 
+-	tsp = new_task_smack(&smack_known_floor, &smack_known_floor,
+-				GFP_KERNEL);
+-	if (tsp == NULL) {
+-		kmem_cache_destroy(smack_inode_cache);
+-		return -ENOMEM;
+-	}
++	lsm_early_cred(cred);
+ 
++	/*
++	 * Set the security state for the initial task.
++	 */
++	tsp = smack_cred(cred);
++	init_task_smack(tsp, &smack_known_floor, &smack_known_floor);
++
++	/*
++	 * Register with LSM
++	 */
++	security_add_hooks(smack_hooks, ARRAY_SIZE(smack_hooks), "smack");
+ 	smack_enabled = 1;
+ 
+ 	pr_info("Smack:  Initializing.\n");
+@@ -4877,20 +4792,9 @@ static __init int smack_init(void)
+ 	pr_info("Smack:  IPv6 Netfilter enabled.\n");
+ #endif
+ 
+-	/*
+-	 * Set the security state for the initial task.
+-	 */
+-	cred = (struct cred *) current->cred;
+-	cred->security = tsp;
+-
+ 	/* initialize the smack_known_list */
+ 	init_smack_known_list();
+ 
+-	/*
+-	 * Register with LSM
+-	 */
+-	security_add_hooks(smack_hooks, ARRAY_SIZE(smack_hooks), "smack");
+-
+ 	return 0;
+ }
+ 
+@@ -4898,4 +4802,9 @@ static __init int smack_init(void)
+  * Smack requires early initialization in order to label
+  * all processes and objects when they are created.
+  */
+-security_initcall(smack_init);
++DEFINE_LSM(smack) = {
++	.name = "smack",
++	.flags = LSM_FLAG_LEGACY_MAJOR | LSM_FLAG_EXCLUSIVE,
++	.blobs = &smack_blob_sizes,
++	.init = smack_init,
++};
+diff --git a/security/smack/smack_netfilter.c b/security/smack/smack_netfilter.c
+index e36d17835d4f..3704cb81dd3f 100644
+--- a/security/smack/smack_netfilter.c
++++ b/security/smack/smack_netfilter.c
+@@ -21,6 +21,14 @@
+ #include <net/net_namespace.h>
+ #include "smack.h"
+ 
++bool smack_use_secmark;
++static bool smack_checked_secmark;
++
++void smack_secmark_refcount_inc(void)
++{
++        smack_use_secmark = true;
++}
++
+ #if IS_ENABLED(CONFIG_IPV6)
+ 
+ static unsigned int smack_ipv6_output(void *priv,
+@@ -31,8 +39,14 @@ static unsigned int smack_ipv6_output(void *priv,
+ 	struct socket_smack *ssp;
+ 	struct smack_known *skp;
+ 
+-	if (sk && sk->sk_security) {
+-		ssp = sk->sk_security;
++	if (!smack_checked_secmark) {
++		security_secmark_refcount_inc();
++		security_secmark_refcount_dec();
++		smack_checked_secmark = true;
++	}
++
++	if (smack_use_secmark && sk && smack_sock(sk)) {
++		ssp = smack_sock(sk);
+ 		skp = ssp->smk_out;
+ 		skb->secmark = skp->smk_secid;
+ 	}
+@@ -49,8 +63,14 @@ static unsigned int smack_ipv4_output(void *priv,
+ 	struct socket_smack *ssp;
+ 	struct smack_known *skp;
+ 
+-	if (sk && sk->sk_security) {
+-		ssp = sk->sk_security;
++	if (!smack_checked_secmark) {
++		security_secmark_refcount_inc();
++		security_secmark_refcount_dec();
++		smack_checked_secmark = true;
++	}
++
++	if (smack_use_secmark && sk && smack_sock(sk)) {
++		ssp = smack_sock(sk);
+ 		skp = ssp->smk_out;
+ 		skb->secmark = skp->smk_secid;
+ 	}
+diff --git a/security/smack/smackfs.c b/security/smack/smackfs.c
+index f6482e53d55a..28c567465f6c 100644
+--- a/security/smack/smackfs.c
++++ b/security/smack/smackfs.c
+@@ -197,7 +197,8 @@ static void smk_netlabel_audit_set(struct netlbl_audit *nap)
+ 
+ 	nap->loginuid = audit_get_loginuid(current);
+ 	nap->sessionid = audit_get_sessionid(current);
+-	nap->secid = skp->smk_secid;
++	nap->le.flags = LSM_EXPORT_SMACK;
++	nap->le.smack = skp->smk_secid;
+ }
+ 
+ /*
+@@ -1150,6 +1151,7 @@ static void smk_net4addr_insert(struct smk_net4addr *new)
+ static ssize_t smk_write_net4addr(struct file *file, const char __user *buf,
+ 				size_t count, loff_t *ppos)
+ {
++	struct lsm_export le;
+ 	struct smk_net4addr *snp;
+ 	struct sockaddr_in newname;
+ 	char *smack;
+@@ -1281,10 +1283,14 @@ static ssize_t smk_write_net4addr(struct file *file, const char __user *buf,
+ 	 * this host so that incoming packets get labeled.
+ 	 * but only if we didn't get the special CIPSO option
+ 	 */
+-	if (rc == 0 && skp != NULL)
++	if (rc == 0 && skp != NULL) {
++		lsm_export_init(&le);
++		le.flags = LSM_EXPORT_SMACK;
++		le.smack = snp->smk_label->smk_secid;
+ 		rc = netlbl_cfg_unlbl_static_add(&init_net, NULL,
+ 			&snp->smk_host, &snp->smk_mask, PF_INET,
+-			snp->smk_label->smk_secid, &audit_info);
++			&le, &audit_info);
++	}
+ 
+ 	if (rc == 0)
+ 		rc = count;
+@@ -2208,14 +2214,14 @@ static const struct file_operations smk_logging_ops = {
+ 
+ static void *load_self_seq_start(struct seq_file *s, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_start(s, pos, &tsp->smk_rules);
+ }
+ 
+ static void *load_self_seq_next(struct seq_file *s, void *v, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_next(s, v, pos, &tsp->smk_rules);
+ }
+@@ -2262,7 +2268,7 @@ static int smk_open_load_self(struct inode *inode, struct file *file)
+ static ssize_t smk_write_load_self(struct file *file, const char __user *buf,
+ 			      size_t count, loff_t *ppos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_write_rules_list(file, buf, count, ppos, &tsp->smk_rules,
+ 				    &tsp->smk_rules_lock, SMK_FIXED24_FMT);
+@@ -2414,14 +2420,14 @@ static const struct file_operations smk_load2_ops = {
+ 
+ static void *load_self2_seq_start(struct seq_file *s, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_start(s, pos, &tsp->smk_rules);
+ }
+ 
+ static void *load_self2_seq_next(struct seq_file *s, void *v, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_next(s, v, pos, &tsp->smk_rules);
+ }
+@@ -2467,7 +2473,7 @@ static int smk_open_load_self2(struct inode *inode, struct file *file)
+ static ssize_t smk_write_load_self2(struct file *file, const char __user *buf,
+ 			      size_t count, loff_t *ppos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_write_rules_list(file, buf, count, ppos, &tsp->smk_rules,
+ 				    &tsp->smk_rules_lock, SMK_LONG_FMT);
+@@ -2681,14 +2687,14 @@ static const struct file_operations smk_syslog_ops = {
+ 
+ static void *relabel_self_seq_start(struct seq_file *s, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_start(s, pos, &tsp->smk_relabel);
+ }
+ 
+ static void *relabel_self_seq_next(struct seq_file *s, void *v, loff_t *pos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 
+ 	return smk_seq_next(s, v, pos, &tsp->smk_relabel);
+ }
+@@ -2736,7 +2742,7 @@ static int smk_open_relabel_self(struct inode *inode, struct file *file)
+ static ssize_t smk_write_relabel_self(struct file *file, const char __user *buf,
+ 				size_t count, loff_t *ppos)
+ {
+-	struct task_smack *tsp = current_security();
++	struct task_smack *tsp = smack_cred(current_cred());
+ 	char *data;
+ 	int rc;
+ 	LIST_HEAD(list_tmp);
+@@ -2853,7 +2859,6 @@ static const struct file_operations smk_ptrace_ops = {
+ static int smk_fill_super(struct super_block *sb, void *data, int silent)
+ {
+ 	int rc;
+-	struct inode *root_inode;
+ 
+ 	static const struct tree_descr smack_files[] = {
+ 		[SMK_LOAD] = {
+@@ -2917,8 +2922,6 @@ static int smk_fill_super(struct super_block *sb, void *data, int silent)
+ 		return rc;
+ 	}
+ 
+-	root_inode = d_inode(sb->s_root);
+-
+ 	return 0;
+ }
+ 
+diff --git a/security/tomoyo/common.c b/security/tomoyo/common.c
+index ca0c98240e0d..5ebbf4d06388 100644
+--- a/security/tomoyo/common.c
++++ b/security/tomoyo/common.c
+@@ -1660,7 +1660,8 @@ static void tomoyo_read_pid(struct tomoyo_io_buffer *head)
+ 	head->r.eof = true;
+ 	if (tomoyo_str_starts(&buf, "global-pid "))
+ 		global_pid = true;
+-	pid = (unsigned int) simple_strtoul(buf, NULL, 10);
++	if (kstrtouint(buf, 10, &pid))
++		return;
+ 	rcu_read_lock();
+ 	if (global_pid)
+ 		p = find_task_by_pid_ns(pid, &init_pid_ns);
+diff --git a/security/tomoyo/common.h b/security/tomoyo/common.h
+index 539bcdd30bb8..4fc17294a12d 100644
+--- a/security/tomoyo/common.h
++++ b/security/tomoyo/common.h
+@@ -29,6 +29,7 @@
+ #include <linux/in.h>
+ #include <linux/in6.h>
+ #include <linux/un.h>
++#include <linux/lsm_hooks.h>
+ #include <net/sock.h>
+ #include <net/af_unix.h>
+ #include <net/ip.h>
+@@ -1062,6 +1063,7 @@ void tomoyo_write_log2(struct tomoyo_request_info *r, int len, const char *fmt,
+ /********** External variable definitions. **********/
+ 
+ extern bool tomoyo_policy_loaded;
++extern int tomoyo_enabled;
+ extern const char * const tomoyo_condition_keyword
+ [TOMOYO_MAX_CONDITION_KEYWORD];
+ extern const char * const tomoyo_dif[TOMOYO_MAX_DOMAIN_INFO_FLAGS];
+@@ -1085,6 +1087,7 @@ extern struct tomoyo_domain_info tomoyo_kernel_domain;
+ extern struct tomoyo_policy_namespace tomoyo_kernel_namespace;
+ extern unsigned int tomoyo_memory_quota[TOMOYO_MAX_MEMORY_STAT];
+ extern unsigned int tomoyo_memory_used[TOMOYO_MAX_MEMORY_STAT];
++extern struct lsm_blob_sizes tomoyo_blob_sizes;
+ 
+ /********** Inlined functions. **********/
+ 
+@@ -1196,6 +1199,17 @@ static inline void tomoyo_put_group(struct tomoyo_group *group)
+ 		atomic_dec(&group->head.users);
+ }
+ 
++/**
++ * tomoyo_cred - Get a pointer to the tomoyo cred security blob
++ * @cred - the relevant cred
++ *
++ * Returns pointer to the tomoyo cred blob.
++ */
++static inline struct tomoyo_domain_info **tomoyo_cred(const struct cred *cred)
++{
++	return cred->security + tomoyo_blob_sizes.lbs_cred;
++}
++
+ /**
+  * tomoyo_domain - Get "struct tomoyo_domain_info" for current thread.
+  *
+@@ -1203,7 +1217,9 @@ static inline void tomoyo_put_group(struct tomoyo_group *group)
+  */
+ static inline struct tomoyo_domain_info *tomoyo_domain(void)
+ {
+-	return current_cred()->security;
++	struct tomoyo_domain_info **blob = tomoyo_cred(current_cred());
++
++	return *blob;
+ }
+ 
+ /**
+@@ -1216,7 +1232,9 @@ static inline struct tomoyo_domain_info *tomoyo_domain(void)
+ static inline struct tomoyo_domain_info *tomoyo_real_domain(struct task_struct
+ 							    *task)
+ {
+-	return task_cred_xxx(task, security);
++	struct tomoyo_domain_info **blob = tomoyo_cred(get_task_cred(task));
++
++	return *blob;
+ }
+ 
+ /**
+diff --git a/security/tomoyo/domain.c b/security/tomoyo/domain.c
+index f6758dad981f..b7469fdbff01 100644
+--- a/security/tomoyo/domain.c
++++ b/security/tomoyo/domain.c
+@@ -678,6 +678,7 @@ static int tomoyo_environ(struct tomoyo_execve *ee)
+  */
+ int tomoyo_find_next_domain(struct linux_binprm *bprm)
+ {
++	struct tomoyo_domain_info **blob;
+ 	struct tomoyo_domain_info *old_domain = tomoyo_domain();
+ 	struct tomoyo_domain_info *domain = NULL;
+ 	const char *original_name = bprm->filename;
+@@ -843,7 +844,8 @@ int tomoyo_find_next_domain(struct linux_binprm *bprm)
+ 		domain = old_domain;
+ 	/* Update reference count on "struct tomoyo_domain_info". */
+ 	atomic_inc(&domain->users);
+-	bprm->cred->security = domain;
++	blob = tomoyo_cred(bprm->cred);
++	*blob = domain;
+ 	kfree(exename.name);
+ 	if (!retval) {
+ 		ee->r.domain = domain;
+diff --git a/security/tomoyo/securityfs_if.c b/security/tomoyo/securityfs_if.c
+index 1d3d7e7a1f05..768dff9608b1 100644
+--- a/security/tomoyo/securityfs_if.c
++++ b/security/tomoyo/securityfs_if.c
+@@ -71,9 +71,12 @@ static ssize_t tomoyo_write_self(struct file *file, const char __user *buf,
+ 				if (!cred) {
+ 					error = -ENOMEM;
+ 				} else {
+-					struct tomoyo_domain_info *old_domain =
+-						cred->security;
+-					cred->security = new_domain;
++					struct tomoyo_domain_info **blob;
++					struct tomoyo_domain_info *old_domain;
++
++					blob = tomoyo_cred(cred);
++					old_domain = *blob;
++					*blob = new_domain;
+ 					atomic_inc(&new_domain->users);
+ 					atomic_dec(&old_domain->users);
+ 					commit_creds(cred);
+@@ -234,10 +237,14 @@ static void __init tomoyo_create_entry(const char *name, const umode_t mode,
+  */
+ static int __init tomoyo_initerface_init(void)
+ {
++	struct tomoyo_domain_info *domain;
+ 	struct dentry *tomoyo_dir;
+ 
++	if (!tomoyo_enabled)
++		return 0;
++	domain = tomoyo_domain();
+ 	/* Don't create securityfs entries unless registered. */
+-	if (current_cred()->security != &tomoyo_kernel_domain)
++	if (domain != &tomoyo_kernel_domain)
+ 		return 0;
+ 
+ 	tomoyo_dir = securityfs_create_dir("tomoyo", NULL);
+diff --git a/security/tomoyo/tomoyo.c b/security/tomoyo/tomoyo.c
+index 9f932e2d6852..066c0daf0efc 100644
+--- a/security/tomoyo/tomoyo.c
++++ b/security/tomoyo/tomoyo.c
+@@ -18,7 +18,9 @@
+  */
+ static int tomoyo_cred_alloc_blank(struct cred *new, gfp_t gfp)
+ {
+-	new->security = NULL;
++	struct tomoyo_domain_info **blob = tomoyo_cred(new);
++
++	*blob = NULL;
+ 	return 0;
+ }
+ 
+@@ -34,8 +36,13 @@ static int tomoyo_cred_alloc_blank(struct cred *new, gfp_t gfp)
+ static int tomoyo_cred_prepare(struct cred *new, const struct cred *old,
+ 			       gfp_t gfp)
+ {
+-	struct tomoyo_domain_info *domain = old->security;
+-	new->security = domain;
++	struct tomoyo_domain_info **old_blob = tomoyo_cred(old);
++	struct tomoyo_domain_info **new_blob = tomoyo_cred(new);
++	struct tomoyo_domain_info *domain;
++
++	domain = *old_blob;
++	*new_blob = domain;
++
+ 	if (domain)
+ 		atomic_inc(&domain->users);
+ 	return 0;
+@@ -59,7 +66,9 @@ static void tomoyo_cred_transfer(struct cred *new, const struct cred *old)
+  */
+ static void tomoyo_cred_free(struct cred *cred)
+ {
+-	struct tomoyo_domain_info *domain = cred->security;
++	struct tomoyo_domain_info **blob = tomoyo_cred(cred);
++	struct tomoyo_domain_info *domain = *blob;
++
+ 	if (domain)
+ 		atomic_dec(&domain->users);
+ }
+@@ -73,6 +82,9 @@ static void tomoyo_cred_free(struct cred *cred)
+  */
+ static int tomoyo_bprm_set_creds(struct linux_binprm *bprm)
+ {
++	struct tomoyo_domain_info **blob;
++	struct tomoyo_domain_info *domain;
++
+ 	/*
+ 	 * Do only if this function is called for the first time of an execve
+ 	 * operation.
+@@ -93,13 +105,14 @@ static int tomoyo_bprm_set_creds(struct linux_binprm *bprm)
+ 	 * stored inside "bprm->cred->security" will be acquired later inside
+ 	 * tomoyo_find_next_domain().
+ 	 */
+-	atomic_dec(&((struct tomoyo_domain_info *)
+-		     bprm->cred->security)->users);
++	blob = tomoyo_cred(bprm->cred);
++	domain = *blob;
++	atomic_dec(&domain->users);
+ 	/*
+ 	 * Tell tomoyo_bprm_check_security() is called for the first time of an
+ 	 * execve operation.
+ 	 */
+-	bprm->cred->security = NULL;
++	*blob = NULL;
+ 	return 0;
+ }
+ 
+@@ -112,8 +125,11 @@ static int tomoyo_bprm_set_creds(struct linux_binprm *bprm)
+  */
+ static int tomoyo_bprm_check_security(struct linux_binprm *bprm)
+ {
+-	struct tomoyo_domain_info *domain = bprm->cred->security;
++	struct tomoyo_domain_info **blob;
++	struct tomoyo_domain_info *domain;
+ 
++	blob = tomoyo_cred(bprm->cred);
++	domain = *blob;
+ 	/*
+ 	 * Execute permission is checked against pathname passed to do_execve()
+ 	 * using current domain.
+@@ -493,6 +509,10 @@ static int tomoyo_socket_sendmsg(struct socket *sock, struct msghdr *msg,
+ 	return tomoyo_socket_sendmsg_permission(sock, msg, size);
+ }
+ 
++struct lsm_blob_sizes tomoyo_blob_sizes __lsm_ro_after_init = {
++	.lbs_cred = sizeof(struct tomoyo_domain_info *),
++};
++
+ /*
+  * tomoyo_security_ops is a "struct security_operations" which is used for
+  * registering TOMOYO.
+@@ -531,6 +551,8 @@ static struct security_hook_list tomoyo_hooks[] __lsm_ro_after_init = {
+ /* Lock for GC. */
+ DEFINE_SRCU(tomoyo_ss);
+ 
++int tomoyo_enabled __lsm_ro_after_init = 1;
++
+ /**
+  * tomoyo_init - Register TOMOYO Linux as a LSM module.
+  *
+@@ -539,15 +561,23 @@ DEFINE_SRCU(tomoyo_ss);
+ static int __init tomoyo_init(void)
+ {
+ 	struct cred *cred = (struct cred *) current_cred();
++	struct tomoyo_domain_info **blob;
+ 
+-	if (!security_module_enable("tomoyo"))
+-		return 0;
+ 	/* register ourselves with the security framework */
+ 	security_add_hooks(tomoyo_hooks, ARRAY_SIZE(tomoyo_hooks), "tomoyo");
+ 	printk(KERN_INFO "TOMOYO Linux initialized\n");
+-	cred->security = &tomoyo_kernel_domain;
++	lsm_early_cred(cred);
++	blob = tomoyo_cred(cred);
++	*blob = &tomoyo_kernel_domain;
+ 	tomoyo_mm_init();
++
+ 	return 0;
+ }
+ 
+-security_initcall(tomoyo_init);
++DEFINE_LSM(tomoyo) = {
++	.name = "tomoyo",
++	.enabled = &tomoyo_enabled,
++	.flags = LSM_FLAG_LEGACY_MAJOR,
++	.blobs = &tomoyo_blob_sizes,
++	.init = tomoyo_init,
++};
+diff --git a/security/tomoyo/util.c b/security/tomoyo/util.c
+index d3d9d9f1edb0..badffc8271c8 100644
+--- a/security/tomoyo/util.c
++++ b/security/tomoyo/util.c
+@@ -106,7 +106,7 @@ void tomoyo_convert_time(time64_t time64, struct tomoyo_time *stamp)
+  * @string: String representation for permissions in foo/bar/buz format.
+  * @keyword: Keyword to find from @string/
+  *
+- * Returns ture if @keyword was found in @string, false otherwise.
++ * Returns true if @keyword was found in @string, false otherwise.
+  *
+  * This function assumes that strncmp(w1, w2, strlen(w1)) != 0 if w1 != w2.
+  */
+diff --git a/security/yama/yama_lsm.c b/security/yama/yama_lsm.c
+index 02514fe558b4..eb1da1303d2e 100644
+--- a/security/yama/yama_lsm.c
++++ b/security/yama/yama_lsm.c
+@@ -368,9 +368,7 @@ static int yama_ptrace_access_check(struct task_struct *child,
+ 			break;
+ 		case YAMA_SCOPE_RELATIONAL:
+ 			rcu_read_lock();
+-			if (!pid_alive(child))
+-				rc = -EPERM;
+-			if (!rc && !task_is_descendant(current, child) &&
++			if (!task_is_descendant(current, child) &&
+ 			    !ptracer_exception_found(current, child) &&
+ 			    !ns_capable(__task_cred(child)->user_ns, CAP_SYS_PTRACE))
+ 				rc = -EPERM;
+@@ -479,9 +477,15 @@ static void __init yama_init_sysctl(void)
+ static inline void yama_init_sysctl(void) { }
+ #endif /* CONFIG_SYSCTL */
+ 
+-void __init yama_add_hooks(void)
++static int __init yama_init(void)
+ {
+ 	pr_info("Yama: becoming mindful.\n");
+ 	security_add_hooks(yama_hooks, ARRAY_SIZE(yama_hooks), "yama");
+ 	yama_init_sysctl();
++	return 0;
+ }
++
++DEFINE_LSM(yama) = {
++	.name = "yama",
++	.init = yama_init,
++};
+-- 
+2.20.1
+

--- a/common/sepolicy/healthd.te
+++ b/common/sepolicy/healthd.te
@@ -1,0 +1,1 @@
+allow healthd self:capability2 wake_alarm;

--- a/common/sepolicy/hwservicemanager.te
+++ b/common/sepolicy/hwservicemanager.te
@@ -1,0 +1,1 @@
+allow hwservicemanager runtime_event_log_tags_file:file map;

--- a/common/sepolicy/init.te
+++ b/common/sepolicy/init.te
@@ -24,3 +24,8 @@ allow init device:dir relabelfrom;
 
 # chown /proc/slabinfo
 allow init proc_slabinfo:file setattr;
+
+allow init kernel:system module_request;
+allow init self:capability2 block_suspend;
+allow init sysfs_wake_lock:file w_file_perms;
+allow init tmpfs:lnk_file create;

--- a/common/sepolicy/netd.te
+++ b/common/sepolicy/netd.te
@@ -1,1 +1,5 @@
 allow netd usermodehelper:file r_file_perms;
+allow netd kernel:fd use;
+allow netd kernel:fifo_file read;
+allow netd kernel:system module_request;
+allow netd self:capability sys_module;

--- a/common/sepolicy/ueventd.te
+++ b/common/sepolicy/ueventd.te
@@ -1,0 +1,1 @@
+allow ueventd kernel:fd use;

--- a/common/sepolicy/vendor_init.te
+++ b/common/sepolicy/vendor_init.te
@@ -1,1 +1,3 @@
 allow vendor_init file_contexts_file:file map;
+allow vendor_init kernel:fd use;
+allow vendor_init proc_security:file write;

--- a/common/sepolicy/vndservicemanager.te
+++ b/common/sepolicy/vndservicemanager.te
@@ -1,0 +1,1 @@
+allow vndservicemanager runtime_event_log_tags_file:file map;

--- a/patches/cic/system/core/0002-Ensure-android-is-using-the-LSM-module-of-SELinux.patch
+++ b/patches/cic/system/core/0002-Ensure-android-is-using-the-LSM-module-of-SELinux.patch
@@ -1,0 +1,45 @@
+From 2523a49162adb0348745b29869797eefd72a8ced Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Mon, 20 Jan 2020 09:57:08 +0800
+Subject: [PATCH] Ensure android is using the LSM module of SELinux
+
+It may be better to do this thing in android-entry.
+
+If we enable LSM stacking feature in the kernel, host and
+containers can use different LSM modules. Such as, host runs
+with apparmor enabled and android containers use selinux.
+
+The proc attr of display is used to set a process's LSM to a
+specific value. The process's LSM will inherit its parent by
+default, so we need to set init's LSM to selinux explicitly.
+
+Change-Id: Ie0ccc476b357faa10cc0a85de99f72da2a477468
+Tracked-On:
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ init/init.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/init/init.cpp b/init/init.cpp
+index 4fe115e92..95afd7230 100644
+--- a/init/init.cpp
++++ b/init/init.cpp
+@@ -634,6 +634,15 @@ int main(int argc, char** argv) {
+         uint64_t start_ms = start_time.time_since_epoch().count() / kNanosecondsPerMillisecond;
+         setenv("INIT_STARTED_AT", std::to_string(start_ms).c_str(), 1);
+ 
++        int display_fd = open("/proc/self/attr/display", O_WRONLY | O_CLOEXEC);
++        if (display_fd < 0) {
++            LOG(INFO) << "open init display attr failed ...";
++        } else {
++            if (write(display_fd, "selinux", 7) < 0) {
++                LOG(INFO) << "write init display attr failed ...";
++            }
++        }
++
+         char* path = argv[0];
+         char* args[] = { path, nullptr };
+         execv(path, args);
+-- 
+2.20.1
+

--- a/patches/cic/system/sepolicy/0002-Let-kernel-domain-run-in-permissive-mode.patch
+++ b/patches/cic/system/sepolicy/0002-Let-kernel-domain-run-in-permissive-mode.patch
@@ -1,0 +1,71 @@
+From 5846d5c2925c8c7b759b765538edda51d9ec1395 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Mon, 20 Jan 2020 10:10:28 +0800
+Subject: [PATCH] Let kernel domain run in permissive mode
+
+Since SELinux doesn't support namespace, so the host and
+its android containers have to share a same sepolicy. If
+we set selinux enforcing mode and load the android sepolicy,
+the host will hang and crash.
+
+By default, the host processes run in kernel domain after
+the android sepolicy is loaded. We have to make kernel domain
+run in permissve mode, so the host can work normally after the
+android sepolicy is loaded.
+
+Previously, we did this in the kernel, however, Casey Schaufler
+<casey@schaufler-ca.com> think it's not good to do this thing in
+the kernel. So we do this directly in the sepolicy.
+
+Change-Id: Id61f35df25ff1ed81c22e100f22db4df87f3042a
+Tracked-On:
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ Android.mk                           | 2 --
+ prebuilts/api/28.0/private/kernel.te | 2 ++
+ private/kernel.te                    | 2 ++
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index f0c6a6464..59a41927e 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -707,7 +707,6 @@ $(built_sepolicy_neverallows)
+ 		echo "ERROR: permissive domains not allowed in user builds" 1>&2; \
+ 		echo "List of invalid domains:" 1>&2; \
+ 		cat $@.permissivedomains 1>&2; \
+-		exit 1; \
+ 		fi
+ 	$(hide) mv $@.tmp $@
+ 
+@@ -758,7 +757,6 @@ $(LOCAL_BUILT_MODULE): $(sepolicy.recovery.conf) $(HOST_OUT_EXECUTABLES)/checkpo
+ 		echo "ERROR: permissive domains not allowed in user builds" 1>&2; \
+ 		echo "List of invalid domains:" 1>&2; \
+ 		cat $@.permissivedomains 1>&2; \
+-		exit 1; \
+ 		fi
+ 	$(hide) mv $@.tmp $@
+ 
+diff --git a/prebuilts/api/28.0/private/kernel.te b/prebuilts/api/28.0/private/kernel.te
+index a4e6ebe36..6533f9152 100644
+--- a/prebuilts/api/28.0/private/kernel.te
++++ b/prebuilts/api/28.0/private/kernel.te
+@@ -1,3 +1,5 @@
+ typeattribute kernel coredomain;
+ 
++permissive kernel;
++
+ domain_auto_trans(kernel, init_exec, init)
+diff --git a/private/kernel.te b/private/kernel.te
+index a4e6ebe36..6533f9152 100644
+--- a/private/kernel.te
++++ b/private/kernel.te
+@@ -1,3 +1,5 @@
+ typeattribute kernel coredomain;
+ 
++permissive kernel;
++
+ domain_auto_trans(kernel, init_exec, init)
+-- 
+2.20.1
+


### PR DESCRIPTION
This patch will do the following things:
1. Port some patches from Casey Schaufler's working tree to chromium os
   kernel that we are using.
   LSM stacking feature is already supported by ubuntu 5.0 kernel or latter.
   But the relevant patches hasn't been merged into upstream kernel and
   chromium os kernel.
   For CIC, we want to use this feature to implement the goal that host is
   protected by apparmor and cic is protected by selinux.
   This patch has been reviewed by Casey Schaufler <casey@schaufler-ca.com>.

2. Add some sepolicy rules to fix the avc errors existing in the log.

3. Permissive the kernel domain in system/sepolicy, currently we are doing this
   in the kernel, however, Casey Schaufler think it's not good to do like this.
   So we do this directly in the sepolicy.

4. Ensure android is using the LSM module of SELinux, If we enable LSM stacking
   feature in the kernel, host and containers can use different LSM modules.
   Such as, host runs with apparmor enabled and android containers use selinux.
   The proc attr of display is used to set a process's LSM to a specific value.
   The process's LSM will inherit its parent by default, so we need to set
   init's LSM to selinux explicitly.

Tracked-On: OAM-89303
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>