### PR TITLE
Update README to include kernel config for secure ADB

### DIFF
--- a/common/host/README
+++ b/common/host/README
@@ -72,6 +72,9 @@ make ARCH=x86_64 menuconfig
 
 # Enable Wi-Fi driver
 # "Device Drivers->Network device support -> Wireless LAN->Intel Wireless WiFi 7000 series driver (new version)"
+
+# Enable Uevent notification of Gadget state (needed for secure ADB)
+# "Device Drivers->USB support -> USB Gadget support ->Uevent notification of Gadget state"
 # Save the config file to same .config file
 
 


### PR DESCRIPTION
- README updated to enable kernel config for USB gadget
ConfigFS Uevent which is needed for secure ADB. This
config also fixes an issue related to settings application
crashing when one clicks on 'Default USB configuration'.

Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>