### PR TITLE
Disabling Fake root to show actual battery indicator status

### DIFF
--- a/common/init.base.rc
+++ b/common/init.base.rc
@@ -62,7 +62,8 @@ on fs
 on boot
     setprop wifi.interface wlan0
     # enable fake battery state, details in system/core/healthd/BatteryMonitor.cpp
-    setprop ro.boot.fake_battery 1
+    # disable fake battery state
+    # setprop ro.boot.fake_battery 1
 #    start delRedundantInput
 
     # Disable rild


### PR DESCRIPTION
as same host os .We tested with test battery module for simulation.
we verified host os and android guest shows same value.

Tracked-On: OAM-89654

Signed-off-by: Balaji, M <m.balaji@intel.com>
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>