### PR TITLE
Disabling Fake boot  property to show actual battery indicator status

### DIFF
--- a/common/init.base.rc
+++ b/common/init.base.rc
@@ -61,8 +61,6 @@ on fs
 
 on boot
     setprop wifi.interface wlan0
-    # enable fake battery state, details in system/core/healthd/BatteryMonitor.cpp
-    setprop ro.boot.fake_battery 1
 #    start delRedundantInput
 
     # Disable rild


### PR DESCRIPTION
Currently Battery indicator is faked by setting property.
Now removed the fake boot property. Tested with test battery
kernel module for simulation.Verified host os and
android container shows same value.

Tracked-On: OAM-89654
Signed-off-by: Balaji, M <m.balaji@intel.com>
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>