### PR TITLE
Enable ADB over network on cic

### DIFF
--- a/cic/cic.mk
+++ b/cic/cic.mk
@@ -95,7 +95,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.gralloc_imp=intel \
     ro.hardware.hwcomposer_imp=intel \
     ro.opengles.version=196610 \
-    ro.product.first_api_level=27
+    ro.product.first_api_level=27 \
+    service.adb.tcp.port=5555
 
 
 PRODUCT_NAME := cic


### PR DESCRIPTION
Basing on the requirement of epic of OAM-87737, we need to enable
secure ADB on cic.
Since we usually connect to cic devices by ADB over network, adb
daemon needs to listen on a network port (Here it's 5555). So
the adb authentication pop-up dialog can be displayed by doing this:

	adb connect localhost:5555

Tracked-On: OAM-89667
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>