### PR TITLE
SD card formatting issue for Android in Container

### DIFF
--- a/patches/common/system/vold/0001-SD-card-formatting-issue-for-Android-in-Container.patch
+++ b/patches/common/system/vold/0001-SD-card-formatting-issue-for-Android-in-Container.patch
@@ -1,0 +1,44 @@
+From 5c9c3b776182e83f460940322b4a39d2ff881d68 Mon Sep 17 00:00:00 2001
+From: nitishat <nitisha.tomar@intel.com>
+Date: Fri, 14 Feb 2020 23:04:12 +0530
+Subject: [PATCH] SD card formatting issue for Android in Container
+
+When SD card is plugged into the system it is shown as unsupported
+and while trying to set it up by formatting the card the operation
+never gets completed.
+
+Tracked-On: OAM-89656
+
+Signed-off-by:Nitisha Tomar <nitisha.tomar@intel.com>
+---
+ model/Disk.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/model/Disk.cpp b/model/Disk.cpp
+index d7b19ac..ead876c 100644
+--- a/model/Disk.cpp
++++ b/model/Disk.cpp
+@@ -55,6 +55,8 @@ static const char* kSgdiskToken = " \t\n";
+ static const char* kSysfsLoopMaxMinors = "/sys/module/loop/parameters/max_part";
+ static const char* kSysfsMmcMaxMinorsDeprecated = "/sys/module/mmcblk/parameters/perdev_minors";
+ static const char* kSysfsMmcMaxMinors = "/sys/module/mmc_block/parameters/perdev_minors";
++//Android in container (docker based) scenario uses the Linux host kernel, so the path is changed.
++static const char* kSysfsMmcMaxMinorsAic = "/sys/module/mmc_block/parameters/mmcblk.perdev_minors";
+ 
+ static const unsigned int kMajorBlockLoop = 7;
+ static const unsigned int kMajorBlockScsiA = 8;
+@@ -564,8 +566,9 @@ int Disk::getMaxMinors() {
+         // Per Documentation/devices.txt this is dynamic
+         std::string tmp;
+         if (!ReadFileToString(kSysfsMmcMaxMinors, &tmp) &&
+-                !ReadFileToString(kSysfsMmcMaxMinorsDeprecated, &tmp)) {
+-            LOG(ERROR) << "Failed to read max minors";
++            !ReadFileToString(kSysfsMmcMaxMinorsDeprecated, &tmp) && 
++            !ReadFileToString(kSysfsMmcMaxMinorsAic, &tmp)) {
++            LOG(ERROR) << "Failed to read max minors"<<tmp;
+             return -errno;
+         }
+         return std::stoi(tmp);
+-- 
+2.25.0
+


### PR DESCRIPTION
When SD card is plugged into the system it is shown as unsupported
and while trying to set it up by formatting the card the operation
never gets completed.

Tracked-On: OAM-89656
Signed-off-by:Nitisha Tomar <nitisha.tomar@intel.com>