### PR TITLE
HAL_Health:Adding permission for Health Service

### DIFF
--- a/cic/cic.mk
+++ b/cic/cic.mk
@@ -56,6 +56,8 @@ PRODUCT_PACKAGES += \
     Browser2 \
     audio.primary.$(TARGET_PRODUCT)
 
+PRODUCT_PACKAGES += android.hardware.health@2.0-service.intel
+
 ifeq ($(TARGET_USE_INTEL_HWCOMPOSER), true)
 PRODUCT_PACKAGES += libva
 endif

--- a/cic_dev/cic_dev.mk
+++ b/cic_dev/cic_dev.mk
@@ -60,6 +60,8 @@ PRODUCT_PACKAGES += \
     ServiceAgent \
     auto_start_apk.sh
 
+PRODUCT_PACKAGES += android.hardware.health@2.0-service.intel
+
 ifeq ($(TARGET_USE_INTEL_HWCOMPOSER), true)
 PRODUCT_PACKAGES += libva
 endif


### PR DESCRIPTION
Porting Health Monitoring Service along with Storage HAL to
enabling health service by adding package details in .mk file.

Changes done:
	1.Storage Metrics enabled along with this permission.
	2. Health Service package name is added.

Tracked-On: OAM-89734
Signed-off-by: tkaur <taranpreet.kaur@intel.com>